### PR TITLE
fix: Member entity의 username 속성 네이밍 변경

### DIFF
--- a/src/main/kotlin/nexters/admin/domain/user/member/Member.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/member/Member.kt
@@ -6,8 +6,8 @@ import javax.persistence.*
 @Entity
 @Table(name = "member")
 class Member(
-        @Column(name = "username", nullable = false)
-        val username: String,
+        @Column(name = "name", nullable = false)
+        val name: String,
 
         @Column(name = "password", nullable = false)
         var password: Password,


### PR DESCRIPTION
## 기존
- Member 엔티티의 `username` 속성은 유저의 이름(ex. 홍길동)을 나타냅니다.
- Administrator 엔티티의 `username` 속성은 유저의 아이디(ex. xxeol2, seolhui@naver.com)를 나타냅니다.

## 변경사항
위 두가지에서 `username`이라는 명칭에 혼동이 올 수 있어 변경했습니다.
 - Member 엔티티의 유저 이름을 나타내는 속성명을 기존의 `username`에서 `name`으로 변경하였습니다.