### PR TITLE
feat: 관리자 로그인 API 구현

### DIFF
--- a/src/main/kotlin/nexters/admin/controller/auth/AuthController.kt
+++ b/src/main/kotlin/nexters/admin/controller/auth/AuthController.kt
@@ -1,0 +1,24 @@
+package nexters.admin.controller.auth
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import nexters.admin.controller.user.TokenResponse
+import nexters.admin.service.auth.AdminLoginRequest
+import nexters.admin.service.auth.AuthService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import javax.validation.Valid
+
+@Tag(name = "Auth", description = "인증")
+@RequestMapping("/api/auth")
+@RestController
+class AuthController(
+        private val authService: AuthService,
+) {
+    @Operation(summary = "관리자 로그인")
+    @PostMapping("/login/admin")
+    fun loginAdmin(@RequestBody @Valid request: AdminLoginRequest): ResponseEntity<TokenResponse> {
+        val token = authService.generateAdminToken(request)
+        return ResponseEntity.ok(TokenResponse(token))
+    }
+}

--- a/src/main/kotlin/nexters/admin/controller/user/UserDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/user/UserDtos.kt
@@ -1,6 +1,5 @@
 package nexters.admin.controller.user
 
-import nexters.admin.domain.user.Password
 import javax.validation.constraints.Pattern
 
 data class UpdatePasswordRequest(

--- a/src/main/kotlin/nexters/admin/controller/user/UserDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/user/UserDtos.kt
@@ -7,7 +7,7 @@ data class UpdatePasswordRequest(
         @field:Pattern(
                 regexp = "^[a-zA-Z0-9!@#$%^*]{8,20}$",
                 message = "비밀번호는 알파벳, 숫자, 특수문자(!,@,#,\\,$,%,^,*) 8~20 글자로 구성되어야 합니다.")
-        val password: Password
+        val password: String
 )
 
 data class TokenResponse(val data: String)

--- a/src/main/kotlin/nexters/admin/domain/user/Password.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/Password.kt
@@ -28,4 +28,8 @@ data class Password(var value: String) {
     init {
         value = value.sha256Encrypt()
     }
+
+    fun isSamePassword(password: Password): Boolean {
+        return this.value == password.value
+    }
 }

--- a/src/main/kotlin/nexters/admin/domain/user/Password.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/Password.kt
@@ -29,7 +29,7 @@ data class Password(var value: String) {
         value = value.sha256Encrypt()
     }
 
-    fun isSamePassword(password: String): Boolean {
-        return this.value == password.sha256Encrypt()
+    fun isSamePassword(password: Password): Boolean {
+        return this.value == password.value
     }
 }

--- a/src/main/kotlin/nexters/admin/domain/user/Password.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/Password.kt
@@ -29,7 +29,7 @@ data class Password(var value: String) {
         value = value.sha256Encrypt()
     }
 
-    fun isSamePassword(password: Password): Boolean {
-        return this.value == password.value
+    fun isSamePassword(password: String): Boolean {
+        return this.value == password.sha256Encrypt()
     }
 }

--- a/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
@@ -21,7 +21,7 @@ class Administrator(
     var id: Long = 0L
 
     fun isSamePassword(password: Password): Boolean {
-        return this.password.value == password.value
+        return this.password.isSamePassword(password)
     }
 
     fun updateLastAccessTime() {

--- a/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
@@ -14,9 +14,17 @@ class Administrator(
         var password: Password,
 
         @Column(name = "last_access_time")
-        var lastAccessTime: LocalDateTime? = null
+        var lastAccessTime: LocalDateTime? = null,
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
+
+    fun isSamePassword(password: Password): Boolean {
+        return this.password.value == password.value
+    }
+
+    fun updateLastAccessTime() {
+        this.lastAccessTime = LocalDateTime.now()
+    }
 }

--- a/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
@@ -20,7 +20,7 @@ class Administrator(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
 
-    fun isSamePassword(password: String): Boolean {
+    fun isSamePassword(password: Password): Boolean {
         return this.password.isSamePassword(password)
     }
 

--- a/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
@@ -20,7 +20,7 @@ class Administrator(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
 
-    fun isSamePassword(password: Password): Boolean {
+    fun isSamePassword(password: String): Boolean {
         return this.password.isSamePassword(password)
     }
 

--- a/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/administrator/Administrator.kt
@@ -14,7 +14,7 @@ class Administrator(
         var password: Password,
 
         @Column(name = "last_access_time")
-        var lastAccessTime: LocalDateTime? = null,
+        var lastAccessTime: LocalDateTime = LocalDateTime.now(),
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/nexters/admin/domain/user/member/Member.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/member/Member.kt
@@ -33,7 +33,7 @@ class Member(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
 
-    fun isSamePassword(password: String): Boolean {
+    fun isSamePassword(password: Password): Boolean {
         return this.password.isSamePassword(password)
     }
 

--- a/src/main/kotlin/nexters/admin/domain/user/member/Member.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/member/Member.kt
@@ -34,7 +34,7 @@ class Member(
     var id: Long = 0L
 
     fun isSamePassword(password: Password): Boolean {
-       return this.password.value == password.value
+        return this.password.isSamePassword(password)
     }
 
     fun updatePassword(password: Password) {

--- a/src/main/kotlin/nexters/admin/domain/user/member/Member.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/member/Member.kt
@@ -33,12 +33,12 @@ class Member(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
 
-    fun isSamePassword(password: Password): Boolean {
+    fun isSamePassword(password: String): Boolean {
         return this.password.isSamePassword(password)
     }
 
-    fun updatePassword(password: Password) {
-        this.password = password
+    fun updatePassword(password: String) {
+        this.password = Password(password)
         this.hasChangedPassword = true
     }
 }

--- a/src/main/kotlin/nexters/admin/repository/AdministratorRepository.kt
+++ b/src/main/kotlin/nexters/admin/repository/AdministratorRepository.kt
@@ -1,0 +1,8 @@
+package nexters.admin.repository
+
+import nexters.admin.domain.user.administrator.Administrator
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AdministratorRepository : JpaRepository<Administrator, Long> {
+    fun findByUsername(username: String): Administrator?
+}

--- a/src/main/kotlin/nexters/admin/service/auth/AuthDtos.kt
+++ b/src/main/kotlin/nexters/admin/service/auth/AuthDtos.kt
@@ -3,6 +3,11 @@ package nexters.admin.service.auth
 import nexters.admin.domain.user.Password
 import javax.validation.constraints.Email
 
+data class AdminLoginRequest(
+        val username: String,
+        val password: Password
+)
+
 data class LoginRequest(
         @field:Email
         val email: String,

--- a/src/main/kotlin/nexters/admin/service/auth/AuthDtos.kt
+++ b/src/main/kotlin/nexters/admin/service/auth/AuthDtos.kt
@@ -1,15 +1,14 @@
 package nexters.admin.service.auth
 
-import nexters.admin.domain.user.Password
 import javax.validation.constraints.Email
 
 data class AdminLoginRequest(
         val username: String,
-        val password: Password
+        val password: String,
 )
 
 data class LoginRequest(
         @field:Email
         val email: String,
-        val password: Password
+        val password: String,
 )

--- a/src/main/kotlin/nexters/admin/service/auth/AuthService.kt
+++ b/src/main/kotlin/nexters/admin/service/auth/AuthService.kt
@@ -2,14 +2,26 @@ package nexters.admin.service.auth
 
 import nexters.admin.support.auth.JwtTokenProvider
 import nexters.admin.exception.UnauthenticatedException
+import nexters.admin.repository.AdministratorRepository
 import nexters.admin.repository.MemberRepository
 import org.springframework.stereotype.Service
 
 @Service
 class AuthService(
+        private val adminRepository: AdministratorRepository,
         private val memberRepository: MemberRepository,
         private val jwtTokenProvider: JwtTokenProvider
 ) {
+    fun generateAdminToken(request: AdminLoginRequest): String {
+        val admin = adminRepository.findByUsername(request.username)
+                ?: throw UnauthenticatedException.loginFail()
+        if (!admin.isSamePassword(request.password)) {
+            throw UnauthenticatedException.loginFail()
+        }
+        admin.updateLastAccessTime()
+        return jwtTokenProvider.generateToken(request.username)
+    }
+
     fun generateMemberToken(request: LoginRequest): String {
         val member = memberRepository.findByEmail(request.email)
                 ?: throw UnauthenticatedException.loginFail()

--- a/src/main/kotlin/nexters/admin/service/auth/AuthService.kt
+++ b/src/main/kotlin/nexters/admin/service/auth/AuthService.kt
@@ -1,5 +1,6 @@
 package nexters.admin.service.auth
 
+import nexters.admin.domain.user.Password
 import nexters.admin.support.auth.JwtTokenProvider
 import nexters.admin.exception.UnauthenticatedException
 import nexters.admin.repository.AdministratorRepository
@@ -15,7 +16,7 @@ class AuthService(
     fun generateAdminToken(request: AdminLoginRequest): String {
         val admin = adminRepository.findByUsername(request.username)
                 ?: throw UnauthenticatedException.loginFail()
-        if (!admin.isSamePassword(request.password)) {
+        if (!admin.isSamePassword(Password(request.password))) {
             throw UnauthenticatedException.loginFail()
         }
         admin.updateLastAccessTime()
@@ -25,7 +26,7 @@ class AuthService(
     fun generateMemberToken(request: LoginRequest): String {
         val member = memberRepository.findByEmail(request.email)
                 ?: throw UnauthenticatedException.loginFail()
-        if (!member.isSamePassword(request.password)) {
+        if (!member.isSamePassword(Password(request.password))) {
             throw UnauthenticatedException.loginFail()
         }
         return jwtTokenProvider.generateToken(member.email)

--- a/src/main/kotlin/nexters/admin/service/user/MemberService.kt
+++ b/src/main/kotlin/nexters/admin/service/user/MemberService.kt
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional
 class MemberService(
         private val memberRepository: MemberRepository
 ) {
-    fun updatePassword(loggedInMember: Member, newPassword: Password) {
+    fun updatePassword(loggedInMember: Member, newPassword: String) {
         loggedInMember.updatePassword(newPassword)
         memberRepository.save(loggedInMember)
     }

--- a/src/test/kotlin/nexters/admin/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/Fixtures.kt
@@ -8,7 +8,7 @@ import nexters.admin.domain.user.member.MemberStatus
 import java.time.LocalDateTime
 
 fun createNewMember(
-        username: String = "정진우",
+        name: String = "정진우",
         password: String = "1234",
         email: String = "jweong@gmail.com",
         gender: Gender = Gender.MALE,
@@ -16,7 +16,7 @@ fun createNewMember(
         status: MemberStatus = MemberStatus.NOT_COMPLETION,
         hasChangedPassword: Boolean = false
 ): Member {
-    return Member(username, Password(password), email, gender, phoneNumber, status, hasChangedPassword)
+    return Member(name, Password(password), email, gender, phoneNumber, status, hasChangedPassword)
 }
 
 fun createNewAdmin(

--- a/src/test/kotlin/nexters/admin/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/Fixtures.kt
@@ -1,9 +1,11 @@
 package nexters.admin
 
 import nexters.admin.domain.user.Password
+import nexters.admin.domain.user.administrator.Administrator
 import nexters.admin.domain.user.member.Gender
 import nexters.admin.domain.user.member.Member
 import nexters.admin.domain.user.member.MemberStatus
+import java.time.LocalDateTime
 
 fun createNewMember(
         username: String = "정진우",
@@ -15,4 +17,12 @@ fun createNewMember(
         hasChangedPassword: Boolean = false
 ): Member {
     return Member(username, Password(password), email, gender, phoneNumber, status, hasChangedPassword)
+}
+
+fun createNewAdmin(
+        username: String = "root",
+        password: String = "1234",
+        lastAccessTime: LocalDateTime = LocalDateTime.now()
+): Administrator {
+    return Administrator(username, Password(password), lastAccessTime)
 }

--- a/src/test/kotlin/nexters/admin/domain/user/PasswordTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/PasswordTest.kt
@@ -15,9 +15,9 @@ class PasswordTest {
 
     @Test
     fun `비밀번호 일치 여부 반환`() {
-        val password = Password("abcd")
-        val differentPassword = Password("abcd1234")
+        val value = "abcd"
+        val password = Password(value)
 
-        password.isSamePassword(differentPassword) shouldBe false
+        password.isSamePassword(value) shouldBe true
     }
 }

--- a/src/test/kotlin/nexters/admin/domain/user/PasswordTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/PasswordTest.kt
@@ -1,5 +1,6 @@
 package nexters.admin.domain.user
 
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 
@@ -10,5 +11,13 @@ class PasswordTest {
         val password = Password("1234")
 
         password.value shouldNotBe "1234"
+    }
+
+    @Test
+    fun `비밀번호 일치 여부 반환`() {
+        val password = Password("abcd")
+        val differentPassword = Password("abcd1234")
+
+        password.isSamePassword(differentPassword) shouldBe false
     }
 }

--- a/src/test/kotlin/nexters/admin/domain/user/PasswordTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/PasswordTest.kt
@@ -15,9 +15,9 @@ class PasswordTest {
 
     @Test
     fun `비밀번호 일치 여부 반환`() {
-        val value = "abcd"
-        val password = Password(value)
+        val password = Password("abcd1234!")
+        val differentPassword = Password("abcd1234")
 
-        password.isSamePassword(value) shouldBe true
+        password.isSamePassword(differentPassword) shouldBe false
     }
 }

--- a/src/test/kotlin/nexters/admin/domain/user/administrator/AdministratorTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/administrator/AdministratorTest.kt
@@ -23,6 +23,6 @@ class AdministratorTest {
         val admin = createNewAdmin(lastAccessTime = prevAccessTime)
 
         admin.updateLastAccessTime()
-        admin.lastAccessTime!! shouldBeGreaterThan prevAccessTime
+        admin.lastAccessTime shouldBeGreaterThan prevAccessTime
     }
 }

--- a/src/test/kotlin/nexters/admin/domain/user/administrator/AdministratorTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/administrator/AdministratorTest.kt
@@ -1,0 +1,29 @@
+package nexters.admin.domain.user.administrator
+
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import nexters.admin.domain.user.Password
+import nexters.admin.createNewAdmin
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class AdministratorTest {
+
+    @Test
+    fun `비밀번호 일치 여부 반환`() {
+        val password = "abcd1234"
+        val admin = createNewAdmin(password = password)
+
+        admin.isSamePassword(Password(password)) shouldBe true
+    }
+
+    @Test
+    fun `현재 시각으로 마지막 접속 시점 수정`() {
+        val prevAccessTime = LocalDateTime.now().minus(3, ChronoUnit.SECONDS)
+        val admin = createNewAdmin(lastAccessTime = prevAccessTime)
+
+        admin.updateLastAccessTime()
+        admin.lastAccessTime!! shouldBeGreaterThan prevAccessTime
+    }
+}

--- a/src/test/kotlin/nexters/admin/domain/user/administrator/AdministratorTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/administrator/AdministratorTest.kt
@@ -3,6 +3,7 @@ package nexters.admin.domain.user.administrator
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import nexters.admin.createNewAdmin
+import nexters.admin.domain.user.Password
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -14,7 +15,7 @@ class AdministratorTest {
         val password = "abcd1234"
         val admin = createNewAdmin(password = password)
 
-        admin.isSamePassword(password) shouldBe true
+        admin.isSamePassword(Password(password)) shouldBe true
     }
 
     @Test

--- a/src/test/kotlin/nexters/admin/domain/user/administrator/AdministratorTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/administrator/AdministratorTest.kt
@@ -2,7 +2,6 @@ package nexters.admin.domain.user.administrator
 
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
-import nexters.admin.domain.user.Password
 import nexters.admin.createNewAdmin
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -15,7 +14,7 @@ class AdministratorTest {
         val password = "abcd1234"
         val admin = createNewAdmin(password = password)
 
-        admin.isSamePassword(Password(password)) shouldBe true
+        admin.isSamePassword(password) shouldBe true
     }
 
     @Test

--- a/src/test/kotlin/nexters/admin/domain/user/member/MemberTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/member/MemberTest.kt
@@ -2,6 +2,7 @@ package nexters.admin.domain.user.member
 
 import io.kotest.matchers.shouldBe
 import nexters.admin.createNewMember
+import nexters.admin.domain.user.Password
 import org.junit.jupiter.api.Test
 
 class MemberTest {
@@ -11,7 +12,7 @@ class MemberTest {
         val password = "abcd1234"
         val member = createNewMember(password = password)
 
-        member.isSamePassword(password) shouldBe true
+        member.isSamePassword(Password(password)) shouldBe true
     }
 
     @Test

--- a/src/test/kotlin/nexters/admin/domain/user/member/MemberTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/member/MemberTest.kt
@@ -2,7 +2,6 @@ package nexters.admin.domain.user.member
 
 import io.kotest.matchers.shouldBe
 import nexters.admin.createNewMember
-import nexters.admin.domain.user.Password
 import org.junit.jupiter.api.Test
 
 class MemberTest {
@@ -12,15 +11,13 @@ class MemberTest {
         val password = "abcd1234"
         val member = createNewMember(password = password)
 
-        member.isSamePassword(Password(password)) shouldBe true
+        member.isSamePassword(password) shouldBe true
     }
 
     @Test
     fun `비밀번호 수정시 초기화 여부도 수정`() {
         val member = createNewMember()
-        val newPassword = Password("abcd1234!")
-
-        member.updatePassword(newPassword)
+        member.updatePassword("abcd1234!")
 
         member.hasChangedPassword shouldBe true
     }


### PR DESCRIPTION
간단하게 어드민 로그인을 구현해보았습니다.

- `POST /api/auth/login/admin`

### 공유사항

1. 일단은 도메인 테스트만 만들었는데, 이 PR이 머지되기 전에 테스트 코드 컨벤션이 충분히 확정되었다 싶으면 바로 작성할께요.
2. MemberController 쪽 PR이 머지된 이후에 AuthController에 일반 회원 로그인도 넣읍시다.
