### PR TITLE
fix: enum 서버 에러 대신 커스텀 예외 반환하도록 구현

### DIFF
--- a/src/main/kotlin/nexters/admin/domain/generation_member/Position.kt
+++ b/src/main/kotlin/nexters/admin/domain/generation_member/Position.kt
@@ -1,5 +1,7 @@
 package nexters.admin.domain.generation_member
 
+import nexters.admin.exception.BadRequestException
+
 enum class Position(val value: String?) {
     DEVELOPER("개발자"),
     DESIGNER("디자이너"),
@@ -8,6 +10,7 @@ enum class Position(val value: String?) {
     ;
 
     companion object {
-        fun from(value: String?): Position = values().first { it.value == value }
+        fun from(value: String?): Position =
+                values().firstOrNull { it.value == value } ?: throw BadRequestException.wrongPosition()
     }
 }

--- a/src/main/kotlin/nexters/admin/domain/generation_member/SubPosition.kt
+++ b/src/main/kotlin/nexters/admin/domain/generation_member/SubPosition.kt
@@ -1,5 +1,7 @@
 package nexters.admin.domain.generation_member
 
+import nexters.admin.exception.BadRequestException
+
 enum class SubPosition(val value: String?) {
     BE("백엔드"),
     FE("프론트엔드"),
@@ -15,6 +17,7 @@ enum class SubPosition(val value: String?) {
     ;
 
     companion object {
-        fun from(value: String?): SubPosition = values().first { it.value == value }
+        fun from(value: String?): SubPosition =
+                values().firstOrNull { it.value == value } ?: throw BadRequestException.wrongSubPosition()
     }
 }

--- a/src/main/kotlin/nexters/admin/domain/user/member/Gender.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/member/Gender.kt
@@ -1,11 +1,14 @@
 package nexters.admin.domain.user.member
 
+import nexters.admin.exception.BadRequestException
+
 enum class Gender(val value: String) {
     MALE("남자"),
     FEMALE("여자"),
     ;
 
     companion object {
-        fun from(value: String): Gender = values().first { it.value == value }
+        fun from(value: String): Gender =
+                values().firstOrNull { it.value == value } ?: throw BadRequestException.wrongGender()
     }
 }

--- a/src/main/kotlin/nexters/admin/domain/user/member/MemberStatus.kt
+++ b/src/main/kotlin/nexters/admin/domain/user/member/MemberStatus.kt
@@ -1,5 +1,7 @@
 package nexters.admin.domain.user.member
 
+import nexters.admin.exception.BadRequestException
+
 enum class MemberStatus(val value: String) {
     NOT_COMPLETION("미이수"),
     COMPLETION("이수"),
@@ -8,6 +10,7 @@ enum class MemberStatus(val value: String) {
     ;
 
     companion object {
-        fun from(value: String): MemberStatus = values().first { it.value == value }
+        fun from(value: String): MemberStatus =
+                values().firstOrNull { it.value == value } ?: throw BadRequestException.wrongMemberStatus()
     }
 }

--- a/src/main/kotlin/nexters/admin/exception/CustomExceptions.kt
+++ b/src/main/kotlin/nexters/admin/exception/CustomExceptions.kt
@@ -1,6 +1,13 @@
 package nexters.admin.exception
 
-class BadRequestException(message: String?) : RuntimeException(message)
+class BadRequestException(message: String?) : RuntimeException(message) {
+    companion object {
+        fun wrongGender() = BadRequestException("올바르지 않은 성별입니다.")
+        fun wrongPosition() = BadRequestException("올바르지 않은 직군입니다.")
+        fun wrongMemberStatus() = BadRequestException("올바르지 않은 활동구분입니다.")
+        fun wrongSubPosition() = BadRequestException("올바르지 않은 세부직군입니다.")
+    }
+}
 
 class UnauthenticatedException(message: String?) : RuntimeException(message) {
     companion object {

--- a/src/test/kotlin/nexters/admin/domain/generation_member/PositionTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/generation_member/PositionTest.kt
@@ -1,0 +1,23 @@
+package nexters.admin.domain.generation_member
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import nexters.admin.exception.BadRequestException
+import org.junit.jupiter.api.Test
+
+class PositionTest {
+
+    @Test
+    fun `올바른 직군을 반환`() {
+        val actual = Position.from("개발자")
+
+        actual shouldBe Position.DEVELOPER
+    }
+
+    @Test
+    fun `올바르지 않은 직군 값이 주어지면 예외를 반환`() {
+        shouldThrow<BadRequestException> {
+            Position.from("invalid")
+        }
+    }
+}

--- a/src/test/kotlin/nexters/admin/domain/generation_member/SubPositionTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/generation_member/SubPositionTest.kt
@@ -1,0 +1,23 @@
+package nexters.admin.domain.generation_member
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import nexters.admin.exception.BadRequestException
+import org.junit.jupiter.api.Test
+
+class SubPositionTest {
+
+    @Test
+    fun `올바른 세부직군을 반환`() {
+        val actual = SubPosition.from("백엔드")
+
+        actual shouldBe SubPosition.BE
+    }
+
+    @Test
+    fun `올바르지 않은 세부직군 값이 주어지면 예외를 반환`() {
+        shouldThrow<BadRequestException> {
+            SubPosition.from("invalid")
+        }
+    }
+}

--- a/src/test/kotlin/nexters/admin/domain/user/member/GenderTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/member/GenderTest.kt
@@ -1,0 +1,24 @@
+package nexters.admin.domain.user.member
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import nexters.admin.domain.generation_member.SubPosition
+import nexters.admin.exception.BadRequestException
+import org.junit.jupiter.api.Test
+
+class GenderTest {
+
+    @Test
+    fun `올바른 성별 반환`() {
+        val actual = Gender.from("남자")
+
+        actual shouldBe Gender.MALE
+    }
+
+    @Test
+    fun `올바르지 않은 성별 값이 주어지면 예외를 반환`() {
+        shouldThrow<BadRequestException> {
+            SubPosition.from("invalid")
+        }
+    }
+}

--- a/src/test/kotlin/nexters/admin/domain/user/member/MemberStatusTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/user/member/MemberStatusTest.kt
@@ -1,0 +1,23 @@
+package nexters.admin.domain.user.member
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import nexters.admin.exception.BadRequestException
+import org.junit.jupiter.api.Test
+
+class MemberStatusTest {
+
+    @Test
+    fun `올바른 활동 구분을 반환`() {
+        val actual = MemberStatus.from("수료")
+
+        actual shouldBe MemberStatus.CERTIFICATED
+    }
+
+    @Test
+    fun `올바르지 않은 활동구분 값이 주어지면 예외를 반환`() {
+        shouldThrow<BadRequestException> {
+            MemberStatus.from("invalid")
+        }
+    }
+}


### PR DESCRIPTION
close #18 

해당 이슈에 대한 버그 처리를 위해 pr 날립니다.

머지 순서는 상관없을 거 같네요.