### PR TITLE
fix: 내 출석 정보 조회 시 관리자 인가가 필요하지 않도록 변경

### DIFF
--- a/src/main/kotlin/nexters/admin/config/InterceptorConfig.kt
+++ b/src/main/kotlin/nexters/admin/config/InterceptorConfig.kt
@@ -22,5 +22,6 @@ class InterceptorConfig(
                 .excludePathPatterns("/api/members/password")
                 .excludePathPatterns("/api/sessions/home")
                 .excludePathPatterns("/api/attendance")
+                .excludePathPatterns("/api/attendance/me")
     }
 }


### PR DESCRIPTION
close #23 

아직 세션 api 쪽이 완성되지 않아서 500이 뜨긴 함.
일단 403 뜨는 현상 제거.

인수테스트의 중요성을 다시 한 번 느끼게 된다