### PR TITLE
test: 인수테스트 기본 틀 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     testImplementation 'io.kotest:kotest-runner-junit5:5.4.2'
     testImplementation 'com.ninja-squad:springmockk:2.0.3'
     testImplementation 'io.kotest.extensions:kotest-extensions-spring:1.1.2'
+    testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'io.rest-assured:kotlin-extensions'
 }
 
 tasks.withType(KotlinCompile) {

--- a/src/main/kotlin/nexters/admin/repository/AdminCacheRepository.kt
+++ b/src/main/kotlin/nexters/admin/repository/AdminCacheRepository.kt
@@ -21,4 +21,8 @@ class AdminCacheRepository(
         adminRepository.findByUsername(username)
                 ?.let { cacheRepository[username] = it }
     }
+
+    fun deleteAll() {
+        cacheRepository = ConcurrentHashMap()
+    }
 }

--- a/src/test/kotlin/nexters/admin/acceptance/AcceptanceFixtures.kt
+++ b/src/test/kotlin/nexters/admin/acceptance/AcceptanceFixtures.kt
@@ -1,0 +1,97 @@
+package nexters.admin.acceptance
+
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import nexters.admin.controller.auth.TokenResponse
+import nexters.admin.controller.user.CreateAdministratorRequest
+import nexters.admin.controller.user.CreateMemberRequest
+import nexters.admin.service.auth.AdminLoginRequest
+import nexters.admin.service.auth.MemberLoginRequest
+import nexters.admin.service.auth.MemberLoginResponse
+import nexters.admin.service.user.FindAllMembersResponse
+import org.springframework.http.MediaType
+
+const val DEFAULT_PASSWORD_LENGTH = 4
+
+fun 회원_전체_조회(adminToken: String): FindAllMembersResponse {
+    return Given {
+        log().all()
+        contentType(MediaType.APPLICATION_JSON_VALUE)
+        auth().oauth2(adminToken)
+    } When {
+        get("/api/members")
+    } Then {
+        statusCode(200)
+    } Extract {
+        `as`(FindAllMembersResponse::class.java)
+    }
+}
+
+fun 회원_생성_토큰_발급(adminToken: String, request: CreateMemberRequest): String {
+    회원_생성(adminToken, request)
+    return 회원_로그인_토큰(request.email, createDefaultPassword(request.phoneNumber))
+}
+
+private fun createDefaultPassword(phoneNumber: String): String {
+    return phoneNumber.substring(phoneNumber.length - DEFAULT_PASSWORD_LENGTH, phoneNumber.length)
+}
+
+fun 회원_로그인_토큰(email: String, password: String): String {
+    return Given {
+        log().all()
+        contentType(MediaType.APPLICATION_JSON_VALUE)
+        body(MemberLoginRequest(email, password))
+    } When {
+        post("/api/auth/login/member")
+    } Then {
+        statusCode(200)
+    } Extract {
+        `as`(MemberLoginResponse::class.java).token
+    }
+}
+
+fun 회원_생성(adminToken: String, request: CreateMemberRequest) {
+    Given {
+        log().all()
+        contentType(MediaType.APPLICATION_JSON_VALUE)
+        auth().oauth2(adminToken)
+        body(request)
+    } When {
+        post("/api/members")
+    } Then {
+        statusCode(200)
+    } Extract { }
+}
+
+fun 관리자_생성_토큰_발급(): String {
+    관리자_생성()
+    return 관리자_로그인_토큰()
+}
+
+fun 관리자_로그인_토큰(): String {
+    return Given {
+        log().all()
+        contentType(MediaType.APPLICATION_JSON_VALUE)
+        body(AdminLoginRequest("test@test.com", "1234"))
+    } When {
+        post("/api/auth/login/admin")
+    } Then {
+        statusCode(200)
+    } Extract {
+        `as`(TokenResponse::class.java).data
+    }
+}
+
+fun 관리자_생성() {
+    Given {
+        log().all()
+        contentType(MediaType.APPLICATION_JSON_VALUE)
+        body(CreateAdministratorRequest("test@test.com", "1234"))
+    } When {
+        post("/api/admin")
+    } Then {
+        statusCode(200)
+    } Extract { }
+}

--- a/src/test/kotlin/nexters/admin/acceptance/MemberAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/admin/acceptance/MemberAcceptanceTest.kt
@@ -1,0 +1,43 @@
+package nexters.admin.acceptance
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import nexters.admin.testsupport.AcceptanceTest
+import nexters.admin.testsupport.generateCreateMemberRequest
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+
+class MemberAcceptanceTest : AcceptanceTest() {
+
+    @Test
+    fun `관리자는 회원을 생성할 수 있다`() {
+        val adminToken = 관리자_생성_토큰_발급()
+        val request = generateCreateMemberRequest()
+        회원_생성(adminToken, request)
+
+        val actual = 회원_전체_조회(adminToken)
+
+        actual.data shouldHaveSize 1
+        actual.data.first().name shouldBe request.name
+    }
+
+    @Test
+    fun `일반 회원은 회원 생성을 할 수 없다`() {
+        val adminToken = 관리자_생성_토큰_발급()
+        val memberToken = 회원_생성_토큰_발급(adminToken, generateCreateMemberRequest())
+
+        Given {
+            log().all()
+            contentType(MediaType.APPLICATION_JSON_VALUE)
+            auth().oauth2(memberToken)
+            body(generateCreateMemberRequest(name = "김태태", email = "kthFake@taetae.com"))
+        } When {
+            post("/api/members")
+        } Then {
+            statusCode(403)
+        }
+    }
+}

--- a/src/test/kotlin/nexters/admin/testsupport/AcceptanceTest.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/AcceptanceTest.kt
@@ -1,0 +1,22 @@
+package nexters.admin.testsupport
+
+import io.restassured.RestAssured
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(DatabaseCleanerCallback::class)
+class AcceptanceTest {
+
+    @LocalServerPort
+    var port = 80
+
+    @BeforeEach
+    fun setUp() {
+        if (RestAssured.port == RestAssured.UNDEFINED_PORT) {
+            RestAssured.port = port
+        }
+    }
+}

--- a/src/test/kotlin/nexters/admin/testsupport/DatabaseCleanser.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/DatabaseCleanser.kt
@@ -1,6 +1,8 @@
 package nexters.admin.testsupport
 
+import nexters.admin.repository.AdminCacheRepository
 import org.springframework.beans.factory.InitializingBean
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import javax.persistence.Entity
@@ -13,6 +15,7 @@ import javax.persistence.metamodel.EntityType
 class DatabaseCleanser(
         @PersistenceContext private val entityManager: EntityManager,
         private val tableNames: MutableList<String> = mutableListOf(),
+        @Autowired private val adminCacheRepository: AdminCacheRepository,
 ) : InitializingBean {
 
     override fun afterPropertiesSet() {
@@ -31,6 +34,7 @@ class DatabaseCleanser(
     fun execute() {
         entityManager.flush()
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate()
+        adminCacheRepository.deleteAll()
         tableNames.forEach {
             entityManager.createNativeQuery("TRUNCATE TABLE $it").executeUpdate()
             entityManager.createNativeQuery("ALTER TABLE $it ALTER COLUMN ID RESTART WITH 1").executeUpdate()

--- a/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
@@ -1,5 +1,6 @@
 package nexters.admin.testsupport
 
+import nexters.admin.controller.user.CreateMemberRequest
 import nexters.admin.domain.attendance.Attendance
 import nexters.admin.domain.attendance.AttendanceStatus
 import nexters.admin.domain.generation_member.GenerationMember
@@ -27,6 +28,20 @@ fun createNewMember(
         hasChangedPassword: Boolean = false,
 ): Member {
     return Member(name, Password(password), email, gender, phoneNumber, status, hasChangedPassword)
+}
+
+fun generateCreateMemberRequest(
+        name: String = "김태현",
+        gender: String = "남자",
+        email: String = "kth990303@naver.com",
+        phoneNumber: String = "01012345678",
+        generation: MutableList<Int> = mutableListOf(22),
+        position: String = "개발자",
+        subPosition: String = "백엔드",
+        status: String = "미이수",
+        isManager: Boolean = false,
+): CreateMemberRequest {
+    return CreateMemberRequest(name, gender, email, phoneNumber, generation, position, subPosition, status, isManager)
 }
 
 fun createNewGenerationMember(

--- a/src/test/kotlin/nexters/admin/testsupport/RepositoryTest.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/RepositoryTest.kt
@@ -1,5 +1,6 @@
 package nexters.admin.testsupport
 
+import nexters.admin.repository.AdminCacheRepository
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
@@ -9,6 +10,6 @@ import org.springframework.context.annotation.Import
 @Retention(AnnotationRetention.RUNTIME)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(DatabaseCleanser::class)
+@Import(DatabaseCleanser::class, AdminCacheRepository::class)
 @ExtendWith(DatabaseCleanerCallback::class)
 annotation class RepositoryTest()


### PR DESCRIPTION
### 우선순위 높지 않음.

## 계기
swagger로 시뮬레이션해본 결과 생각보다 많은 버그들이 있었습니다. 
- 의도치 않은 http status 반환
- 올바르지 않은 인증/인가 로직 처리

인수 테스트가 있었다면 사전에 미리 검증해놓을 수 있었으리라 판단합니다.

## 인수테스트 격리
1. `AdminCacheRepository`는 ConcurrentHashMap을 이용합니다. 
2. 인수테스트에서는 `@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)`와 `@ExtendWith(DatabaseCleanerCallback::class)`를 사용합니다. 하지만 1번에서 언급한 부분 때문에 `AdminCacheRepository`는 초기화되지 않습니다.
3. 스프링 빈 생명주기에 의거, DatabaseCleanerCallback 은 빈 초기화 콜백 과정에서 호출됩니다. 즉, `@Autowired private val adminCacheRepository: AdminCacheRepository`로 빈 주입이 가능하며 `execute`과정에서 `concurrentHashMap` 자료구조를 비워줄 수 있습니다.


## 진행상황
기본 틀 정도만 작성해놨으며, RestAssured를 이용했습니다.
점진적으로 추가하는 것도 생각중입니다. 

## 리뷰받고 싶은 사항
- Annotation class로 만들어보려다가, `RestAssured`의 필수적인 초기 port 지정, `@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)` 환경의 필요성 때문에 상속 구조를 활용했습니다. Annotation class로 만들 수 있다면 조언 부탁드려요
