### PR TITLE
feat: DB에서 is_manager 컬럼 제거

### DIFF
--- a/src/main/kotlin/nexters/admin/controller/user/UserDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/user/UserDtos.kt
@@ -13,7 +13,6 @@ data class CreateMemberRequest(
         val position: String?,
         val subPosition: String?,
         val status: String,
-        val isManager: Boolean,
 )
 
 data class CreateAdministratorRequest(

--- a/src/main/kotlin/nexters/admin/domain/generation_member/GenerationMember.kt
+++ b/src/main/kotlin/nexters/admin/domain/generation_member/GenerationMember.kt
@@ -31,9 +31,6 @@ class GenerationMember(
 
         @Column(name = "is_completable", nullable = false)
         var isCompletable: Boolean = true,
-
-        @Column(name = "is_manager", nullable = false)
-        var isManager: Boolean = false,
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/nexters/admin/domain/generation_member/GenerationMember.kt
+++ b/src/main/kotlin/nexters/admin/domain/generation_member/GenerationMember.kt
@@ -43,4 +43,8 @@ class GenerationMember(
         this.position = position
         this.subPosition = subPosition
     }
+
+    fun isManager(): Boolean {
+        return this.position == Position.MANAGER
+    }
 }

--- a/src/main/kotlin/nexters/admin/service/user/MemberService.kt
+++ b/src/main/kotlin/nexters/admin/service/user/MemberService.kt
@@ -52,7 +52,6 @@ class MemberService(
                         generation = request.generations.last(),
                         position = Position.from(request.position),
                         subPosition = SubPosition.from(request.subPosition),
-                        isManager = request.isManager
                 )
         )
         request.generations.removeLast()
@@ -68,7 +67,6 @@ class MemberService(
                                     position = Position.from(request.position),
                                     subPosition = SubPosition.from(request.subPosition),
                                     score = null,
-                                    isManager = request.isManager
                             )
                     )
                 }

--- a/src/main/kotlin/nexters/admin/service/user/UserDtos.kt
+++ b/src/main/kotlin/nexters/admin/service/user/UserDtos.kt
@@ -1,5 +1,6 @@
 package nexters.admin.service.user
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import nexters.admin.domain.generation_member.GenerationMember
 import nexters.admin.domain.user.member.Member
 
@@ -17,6 +18,7 @@ data class FindMemberResponse(
         val position: String?,
         val subPosition: String?,
         val status: String,
+        @get:JsonProperty(value = "isManager")
         val isManager: Boolean,
 ) {
     companion object {
@@ -31,7 +33,7 @@ data class FindMemberResponse(
                     generationMembers.last().position?.value ?: "",
                     generationMembers.last().subPosition?.value ?: "",
                     member.status.value,
-                    generationMembers.last().isManager
+                    generationMembers.last().isManager()
             )
         }
     }

--- a/src/test/kotlin/nexters/admin/domain/generation_member/GenerationMemberTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/generation_member/GenerationMemberTest.kt
@@ -15,4 +15,11 @@ class GenerationMemberTest {
         generationMember.position shouldBe Position.DESIGNER
         generationMember.subPosition shouldBe null
     }
+
+    @Test
+    fun `운영진 여부 반환`() {
+        val generationMember =  createNewGenerationMember(position = Position.MANAGER)
+
+        generationMember.isManager() shouldBe true
+    }
 }

--- a/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
@@ -40,7 +40,6 @@ class MemberServiceTest(
                         "개발자",
                         "백엔드",
                         "미이수",
-                        false
                 )
         )
 
@@ -62,7 +61,6 @@ class MemberServiceTest(
                         "개발자",
                         "백엔드",
                         "미이수",
-                        false
                 )
         )
 
@@ -86,7 +84,6 @@ class MemberServiceTest(
                         "개발자",
                         "백엔드",
                         "미이수",
-                        false
                 )
         )
 
@@ -110,7 +107,6 @@ class MemberServiceTest(
                         "개발자",
                         "백엔드",
                         "미이수",
-                        false
                 )
         )
 

--- a/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
@@ -36,9 +36,8 @@ fun createNewGenerationMember(
         subPosition: SubPosition = SubPosition.BE,
         score: Int = 100,
         isCompletable: Boolean = true,
-        isManager: Boolean = false,
 ): GenerationMember {
-    return GenerationMember(memberId, generation, position, subPosition, score, isCompletable, isManager)
+    return GenerationMember(memberId, generation, position, subPosition, score, isCompletable)
 }
 
 fun createNewAdmin(


### PR DESCRIPTION
기수회원 정보에서 position 컬럼 값이 MANAGER인지 아닌지의 여부만으로 운영진 여부 판별하도록 수정했습니다.

가장 큰 이유는 같은 데이터가 중복으로 관리됨에 따른 데이터 이상 현상에 대한 우려 때문입니다.

closes #30