### PR TITLE
feat: kotlin 관련 swagger 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
+    implementation 'org.springdoc:springdoc-openapi-kotlin:1.6.9'
     compileOnly("io.jsonwebtoken:jjwt-api:0.11.2")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")


### PR DESCRIPTION
close #36 

아래와 같이 nullable한 경우를 제외하곤 레드닷이 보이게 설정.
![image](https://user-images.githubusercontent.com/57135043/220270646-5002e137-dbdc-46f2-817c-ba4c61afe2b4.png)

Java와 다르게 의존성 추가를 해주어야 보이더라구요.