### PR TITLE
refactor: SessionDto Controller/Service 레이어 분리 및 속성 수정

### DIFF
--- a/src/main/kotlin/nexters/admin/controller/session/SessionController.kt
+++ b/src/main/kotlin/nexters/admin/controller/session/SessionController.kt
@@ -4,10 +4,8 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import nexters.admin.domain.session.Session
-import nexters.admin.service.session.CreateSessionRequest
 import nexters.admin.service.session.CreateSessionResponse
 import nexters.admin.service.session.SessionService
-import nexters.admin.service.session.UpdateSessionRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid

--- a/src/main/kotlin/nexters/admin/controller/session/SessionDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/session/SessionDtos.kt
@@ -1,7 +1,6 @@
 package nexters.admin.controller.session
 
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 data class CreateSessionRequest(
         val title: String,
@@ -10,8 +9,6 @@ data class CreateSessionRequest(
         val generation: Int,
         val sessionTime: LocalDate,
         val week: Int,
-        val startAttendTime: LocalDateTime,
-        val endAttendTime: LocalDateTime
 )
 
 data class UpdateSessionRequest(
@@ -21,6 +18,4 @@ data class UpdateSessionRequest(
         val generation: Int,
         val sessionTime: LocalDate,
         val week: Int,
-        val startAttendTime: LocalDateTime,
-        val endAttendTime: LocalDateTime
 )

--- a/src/main/kotlin/nexters/admin/controller/session/SessionDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/session/SessionDtos.kt
@@ -1,0 +1,26 @@
+package nexters.admin.controller.session
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class CreateSessionRequest(
+        val title: String,
+        val description: String,
+        val message: String,
+        val generation: Int,
+        val sessionTime: LocalDate,
+        val week: Int,
+        val startAttendTime: LocalDateTime,
+        val endAttendTime: LocalDateTime
+)
+
+data class UpdateSessionRequest(
+        val title: String,
+        val description: String,
+        val message: String,
+        val generation: Int,
+        val sessionTime: LocalDate,
+        val week: Int,
+        val startAttendTime: LocalDateTime,
+        val endAttendTime: LocalDateTime
+)

--- a/src/main/kotlin/nexters/admin/controller/session/SessionDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/session/SessionDtos.kt
@@ -5,8 +5,8 @@ import java.time.LocalDateTime
 
 data class CreateSessionRequest(
         val title: String,
-        val description: String,
-        val message: String,
+        val description: String?,
+        val message: String?,
         val generation: Int,
         val sessionTime: LocalDate,
         val week: Int,
@@ -16,8 +16,8 @@ data class CreateSessionRequest(
 
 data class UpdateSessionRequest(
         val title: String,
-        val description: String,
-        val message: String,
+        val description: String?,
+        val message: String?,
         val generation: Int,
         val sessionTime: LocalDate,
         val week: Int,

--- a/src/main/kotlin/nexters/admin/service/session/SessionDtos.kt
+++ b/src/main/kotlin/nexters/admin/service/session/SessionDtos.kt
@@ -1,30 +1,6 @@
 package nexters.admin.service.session
 
-import java.time.LocalDate
-import java.time.LocalDateTime
-
-data class CreateSessionRequest(
-        val title: String,
-        val description: String,
-        val message: String,
-        val generation: Int,
-        val sessionTime: LocalDate,
-        val week: Int,
-        val startAttendTime: LocalDateTime,
-        val endAttendTime: LocalDateTime
-)
-
 data class CreateSessionResponse(
         val sessionId: Long
 )
 
-data class UpdateSessionRequest(
-        val title: String,
-        val description: String,
-        val message: String,
-        val generation: Int,
-        val sessionTime: LocalDate,
-        val week: Int,
-        val startAttendTime: LocalDateTime,
-        val endAttendTime: LocalDateTime
-)

--- a/src/main/kotlin/nexters/admin/service/session/SessionService.kt
+++ b/src/main/kotlin/nexters/admin/service/session/SessionService.kt
@@ -26,8 +26,6 @@ class SessionService(
                         generation = request.generation,
                         sessionTime = request.sessionTime,
                         week = request.week,
-                        startAttendTime = request.startAttendTime,
-                        endAttendTime = request.endAttendTime
                 )
         )
 
@@ -44,13 +42,11 @@ class SessionService(
 
         session.apply {
             title = request.title
-            description = request.description
-            message = request.message
+            description = request.description ?: session.description
+            message = request.message ?: session.message
             generation = request.generation
             sessionTime = request.sessionTime
             week = request.week
-            startAttendTime = request.startAttendTime
-            endAttendTime = request.endAttendTime
         }
 
         sessionRepository.save(session)

--- a/src/main/kotlin/nexters/admin/service/session/SessionService.kt
+++ b/src/main/kotlin/nexters/admin/service/session/SessionService.kt
@@ -1,7 +1,8 @@
 package nexters.admin.service.session
 
+import nexters.admin.controller.session.CreateSessionRequest
+import nexters.admin.controller.session.UpdateSessionRequest
 import nexters.admin.domain.session.Session
-import nexters.admin.exception.BadRequestException
 import nexters.admin.exception.NotFoundException
 import nexters.admin.repository.SessionRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -38,7 +39,8 @@ class SessionService(
     }
 
     fun updateSession(sessionId: Long, request: UpdateSessionRequest) {
-        val session = sessionRepository.findByIdOrNull(sessionId) ?: throw NotFoundException.sessionNotFound()
+        val session = sessionRepository.findByIdOrNull(sessionId)
+                ?: throw NotFoundException.sessionNotFound()
 
         session.apply {
             title = request.title

--- a/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
@@ -2,6 +2,8 @@ package nexters.admin.service.session
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import nexters.admin.controller.session.CreateSessionRequest
+import nexters.admin.controller.session.UpdateSessionRequest
 import nexters.admin.repository.SessionRepository
 import nexters.admin.testsupport.ApplicationTest
 import org.junit.jupiter.api.Test
@@ -12,8 +14,8 @@ import java.time.LocalDateTime
 
 @ApplicationTest
 class SessionServiceTest(
-    @Autowired private val sessionService: SessionService,
-    @Autowired private val sessionRepository: SessionRepository,
+        @Autowired private val sessionService: SessionService,
+        @Autowired private val sessionRepository: SessionRepository,
 ) {
 
     @Test

--- a/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
@@ -6,6 +6,7 @@ import nexters.admin.controller.session.CreateSessionRequest
 import nexters.admin.controller.session.UpdateSessionRequest
 import nexters.admin.repository.SessionRepository
 import nexters.admin.testsupport.ApplicationTest
+import nexters.admin.testsupport.createNewSession
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
@@ -86,18 +87,9 @@ class SessionServiceTest(
 
     @Test
     fun `세션 수정`() {
-        val id = sessionService.createSession(
-                CreateSessionRequest(
-                        title = "Test title",
-                        description = "Test description",
-                        message = "Test message",
-                        generation = 22,
-                        sessionTime = LocalDate.now(),
-                        week = 3,
-                )
-        )
-
-        sessionService.updateSession(id, UpdateSessionRequest(
+        val session = createNewSession()
+        sessionRepository.save(session)
+        sessionService.updateSession(session.id, UpdateSessionRequest(
                 title = "Updated Title",
                 description = "Test description",
                 message = "Test message",
@@ -106,10 +98,11 @@ class SessionServiceTest(
                 week = 3,
         ))
 
-        val found = sessionRepository.findByIdOrNull(id)
+        val found = sessionRepository.findByIdOrNull(session.id)
 
         found shouldNotBe null
         found?.title shouldBe "Updated Title"
+        found?.startAttendTime shouldBe session.startAttendTime
     }
 
     @Test

--- a/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @ApplicationTest
 class SessionServiceTest(
@@ -28,8 +27,6 @@ class SessionServiceTest(
                         generation = 22,
                         sessionTime = LocalDate.now(),
                         week = 3,
-                        startAttendTime = LocalDateTime.now(),
-                        endAttendTime = LocalDateTime.now()
                 )
         )
 
@@ -49,8 +46,6 @@ class SessionServiceTest(
                         generation = 22,
                         sessionTime = LocalDate.now(),
                         week = 3,
-                        startAttendTime = LocalDateTime.now(),
-                        endAttendTime = LocalDateTime.now()
                 )
         )
 
@@ -69,8 +64,6 @@ class SessionServiceTest(
                         generation = 22,
                         sessionTime = LocalDate.now(),
                         week = 2,
-                        startAttendTime = LocalDateTime.now(),
-                        endAttendTime = LocalDateTime.now()
                 )
         )
         sessionService.createSession(
@@ -81,8 +74,6 @@ class SessionServiceTest(
                         generation = 22,
                         sessionTime = LocalDate.now(),
                         week = 3,
-                        startAttendTime = LocalDateTime.now(),
-                        endAttendTime = LocalDateTime.now()
                 )
         )
 
@@ -103,8 +94,6 @@ class SessionServiceTest(
                         generation = 22,
                         sessionTime = LocalDate.now(),
                         week = 3,
-                        startAttendTime = LocalDateTime.now(),
-                        endAttendTime = LocalDateTime.now()
                 )
         )
 
@@ -115,10 +104,7 @@ class SessionServiceTest(
                 generation = 22,
                 sessionTime = LocalDate.now(),
                 week = 3,
-                startAttendTime = LocalDateTime.now(),
-                endAttendTime = LocalDateTime.now()
         ))
-
 
         val found = sessionRepository.findByIdOrNull(id)
 
@@ -136,8 +122,6 @@ class SessionServiceTest(
                         generation = 22,
                         sessionTime = LocalDate.now(),
                         week = 3,
-                        startAttendTime = LocalDateTime.now(),
-                        endAttendTime = LocalDateTime.now()
                 )
         )
 


### PR DESCRIPTION
- 기존 Session관련 모든 Dto가 Service레이어에 존재했는데, Request 관련 Dto는 Controller 레이어로 옮겼습니다.
- CreateSessionRequest / UpdateSessionRequest 에서 출석시간 관련 속성들(startAttendTime, endAttendTime) 삭제했습니다.