### PR TITLE
fix: 일반 회원 기능들이 동작하지 않던 버그를 수정한다

### DIFF
--- a/src/main/kotlin/nexters/admin/config/WebMvcConfig.kt
+++ b/src/main/kotlin/nexters/admin/config/WebMvcConfig.kt
@@ -1,11 +1,19 @@
 package nexters.admin.config
 
+import nexters.admin.support.auth.LoginUserResolver
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class CorsConfig: WebMvcConfigurer {
+class WebMvcConfig(
+        val loginUserResolver: LoginUserResolver,
+) : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(loginUserResolver)
+    }
 
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")

--- a/src/main/kotlin/nexters/admin/controller/user/UserDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/user/UserDtos.kt
@@ -1,7 +1,7 @@
 package nexters.admin.controller.user
 
 import javax.validation.constraints.Email
-import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
 
 data class CreateMemberRequest(
         val name: String,
@@ -21,9 +21,7 @@ data class CreateAdministratorRequest(
 )
 
 data class UpdatePasswordRequest(
-        @field:Pattern(
-                regexp = "^[a-zA-Z0-9!@#$%^*]{8,20}$",
-                message = "비밀번호는 알파벳, 숫자, 특수문자(!,@,#,\\,$,%,^,*) 8~20 글자로 구성되어야 합니다.")
+        @field:Size(min = 8, max = 20, message = "비밀번호는 8~20 글자로 구성되어야 합니다.")
         val password: String,
 )
 

--- a/src/test/kotlin/nexters/admin/acceptance/MemberAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/admin/acceptance/MemberAcceptanceTest.kt
@@ -2,9 +2,12 @@ package nexters.admin.acceptance
 
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
+import nexters.admin.controller.user.UpdatePasswordRequest
+import nexters.admin.service.user.FindProfileResponse
 import nexters.admin.testsupport.AcceptanceTest
 import nexters.admin.testsupport.generateCreateMemberRequest
 import org.junit.jupiter.api.Test
@@ -38,6 +41,47 @@ class MemberAcceptanceTest : AcceptanceTest() {
             post("/api/members")
         } Then {
             statusCode(403)
+        }
+    }
+
+    @Test
+    fun `로그인한 상태로 내 정보를 조회할 수 있다`() {
+        val adminToken = 관리자_생성_토큰_발급()
+        val request = generateCreateMemberRequest()
+        회원_생성(adminToken, request)
+        val memberToken = 회원_로그인_토큰(request.email, "5678")
+
+        val response = Given {
+            log().all()
+            header("Authorization", "Bearer $memberToken")
+            contentType(MediaType.APPLICATION_JSON_VALUE)
+        } When {
+            get("/api/members/me")
+        } Then {
+            statusCode(200)
+        } Extract {
+            `as`(FindProfileResponse::class.java)
+        }
+
+        response.name shouldBe request.name
+    }
+
+    @Test
+    fun `비밀번호 변경 시 8~20자로 변경하면 변경된다`() {
+        val adminToken = 관리자_생성_토큰_발급()
+        val request = generateCreateMemberRequest()
+        회원_생성(adminToken, request)
+        val memberToken = 회원_로그인_토큰(request.email, "5678")
+
+        Given {
+            log().all()
+            contentType(MediaType.APPLICATION_JSON_VALUE)
+            auth().oauth2(memberToken)
+            body(UpdatePasswordRequest("12345678"))
+        } When {
+            put("/api/members/password")
+        } Then {
+            statusCode(200)
         }
     }
 }


### PR DESCRIPTION
close #19 

## 우선순위 높음 - 일반회원 기능들 이 pr 머지 안되면 모두 아예 동작 안함
<img width="702" alt="image" src="https://user-images.githubusercontent.com/57135043/220858318-7101563e-c503-45fd-af6d-6c230492f03d.png">

위 사진처럼 500에러가 뜨는 버그 수정

로그인한 회원 여부인지 판단해주는 LoginUserResolver가 HandlerArgumentResolver의 구현체입니다. 아규먼트리졸버는 `WebMvcConfigurer`에서 리졸버 목록에 등록이 돼있어야 가능합니다.
디버깅으로 발견되지 않는 케이스여서 한참 헤맸네요...

추가로 인수테스트, 그리고 비밀번호 업데이트 시 8~20자만 만족해도 변경이 되도록를작성했습니다.