### PR TITLE
fix: open session in view 설정 적용

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    open-in-view: false
+    open-in-view: true
     properties:
       hibernate:
         show_sql: true
@@ -31,4 +31,3 @@ springdoc:
   paths-to-match:
     - /api/**
     - /health-check
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-    open-in-view: false
+    open-in-view: true
     properties:
       hibernate:
         show_sql: true

--- a/src/test/kotlin/nexters/admin/acceptance/AcceptanceFixtures.kt
+++ b/src/test/kotlin/nexters/admin/acceptance/AcceptanceFixtures.kt
@@ -7,6 +7,7 @@ import io.restassured.module.kotlin.extensions.When
 import nexters.admin.controller.auth.TokenResponse
 import nexters.admin.controller.user.CreateAdministratorRequest
 import nexters.admin.controller.user.CreateMemberRequest
+import nexters.admin.controller.user.UpdatePasswordRequest
 import nexters.admin.service.auth.AdminLoginRequest
 import nexters.admin.service.auth.MemberLoginRequest
 import nexters.admin.service.auth.MemberLoginResponse
@@ -63,6 +64,19 @@ fun 회원_생성(adminToken: String, request: CreateMemberRequest) {
     } Then {
         statusCode(200)
     } Extract { }
+}
+
+fun 비밀번호_수정(memberToken: String, newPassword: String) {
+    Given {
+        log().all()
+        contentType(MediaType.APPLICATION_JSON_VALUE)
+        auth().oauth2(memberToken)
+        body(UpdatePasswordRequest( newPassword))
+    } When {
+        put("/api/members/password")
+    } Then {
+        statusCode(200)
+    }
 }
 
 fun 관리자_생성_토큰_발급(): String {


### PR DESCRIPTION
closes #44

- 기본적으로 회원의 비밀번호 수정이 적용되지 않는 버그 해결을 위함. 
- 아마도 회원과 관련된 대부분의 상태 변경 로직이 동작하지 않고 있을 것. 

### 버그 원인

OSIV 설정이 false라서 ArgumentResolver를 통해 컨트롤러에서 전달받은 Member가 영속성 컨텍스트에서 관리되지 않음. 때문에 해당 회원의 상태를 수정하더라도 DB에 반영되지 않은 것으로 보임.