### PR TITLE
fix: 기수 생성이 되지 않던 버그를 수정한다

### DIFF
--- a/src/main/kotlin/nexters/admin/controller/generation/GenerationController.kt
+++ b/src/main/kotlin/nexters/admin/controller/generation/GenerationController.kt
@@ -2,10 +2,10 @@ package nexters.admin.controller.generation
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import nexters.admin.service.generation.CreateGenerationRequest
+import nexters.admin.service.generation.FindCurrentGeneration
 import nexters.admin.service.generation.GenerationResponse
+import nexters.admin.service.generation.GenerationResponses
 import nexters.admin.service.generation.GenerationService
-import nexters.admin.service.generation.UpdateGenerationRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
@@ -19,22 +19,16 @@ class GenerationController(
 
     @Operation(summary = "현재 기수 조회")
     @GetMapping("/current")
-    fun getCurrentGeneration(): ResponseEntity<GenerationResponse> {
-        val generation = generationService.findCurrentGeneration().let {
-            GenerationResponse.from(it)
-        }
-
-        return ResponseEntity.ok(generation)
+    fun getCurrentGeneration(): ResponseEntity<FindCurrentGeneration> {
+        val findCurrentGeneration = generationService.findCurrentGeneration()
+        return ResponseEntity.ok(findCurrentGeneration)
     }
 
     @Operation(summary = "전체 기수 조회")
     @GetMapping
-    fun getAllGenerations(): ResponseEntity<List<GenerationResponse>> {
-        val generations = generationService.findAllGeneration().map {
-            GenerationResponse.from(it)
-        }
-
-        return ResponseEntity.ok(generations)
+    fun getAllGenerations(): ResponseEntity<GenerationResponses> {
+        val generationResponses = generationService.findAllGeneration()
+        return ResponseEntity.ok(generationResponses)
     }
 
     @Operation(summary = "기수 추가")
@@ -43,7 +37,6 @@ class GenerationController(
             @RequestBody @Valid request: CreateGenerationRequest
     ): ResponseEntity<Void> {
         generationService.createGeneration(request)
-
         return ResponseEntity.ok().build()
     }
 
@@ -53,7 +46,6 @@ class GenerationController(
             @PathVariable generation: Int,
     ): ResponseEntity<Void> {
         generationService.deleteGeneration(generation)
-
         return ResponseEntity.ok().build()
     }
 
@@ -64,7 +56,6 @@ class GenerationController(
             @RequestBody @Valid request: UpdateGenerationRequest,
     ): ResponseEntity<Void> {
         generationService.updateGeneration(generation, request)
-
         return ResponseEntity.ok().build()
     }
 
@@ -73,11 +64,7 @@ class GenerationController(
     fun getGenerationDetail(
             @PathVariable generation: Int,
     ): ResponseEntity<GenerationResponse> {
-        val generation = generationService.findGeneration(generation).let {
-            GenerationResponse.from(it)
-        }
-
-        return ResponseEntity.ok(generation)
+        val generationResponse = generationService.findGeneration(generation)
+        return ResponseEntity.ok(generationResponse)
     }
-
 }

--- a/src/main/kotlin/nexters/admin/controller/generation/GenerationController.kt
+++ b/src/main/kotlin/nexters/admin/controller/generation/GenerationController.kt
@@ -1,7 +1,6 @@
 package nexters.admin.controller.generation
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import nexters.admin.service.generation.CreateGenerationRequest
 import nexters.admin.service.generation.GenerationResponse
@@ -49,32 +48,32 @@ class GenerationController(
     }
 
     @Operation(summary = "기수 삭제")
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/{generation}")
     fun removeGeneration(
-            @PathVariable id: Long
+            @PathVariable generation: Int,
     ): ResponseEntity<Void> {
-        generationService.deleteGeneration(id)
+        generationService.deleteGeneration(generation)
 
         return ResponseEntity.ok().build()
     }
 
     @Operation(summary = "기수 수정")
-    @PutMapping("/{id}")
+    @PutMapping("/{generation}")
     fun updateGeneration(
-            @PathVariable id: Long,
-            @RequestBody @Valid request: UpdateGenerationRequest
+            @PathVariable generation: Int,
+            @RequestBody @Valid request: UpdateGenerationRequest,
     ): ResponseEntity<Void> {
-        generationService.updateGeneration(id, request)
+        generationService.updateGeneration(generation, request)
 
         return ResponseEntity.ok().build()
     }
 
     @Operation(summary = "기수 상세조회")
-    @GetMapping("/{id}")
+    @GetMapping("/{generation}")
     fun getGenerationDetail(
-            @PathVariable id: Long
+            @PathVariable generation: Int,
     ): ResponseEntity<GenerationResponse> {
-        val generation = generationService.findGeneration(id).let {
+        val generation = generationService.findGeneration(generation).let {
             GenerationResponse.from(it)
         }
 

--- a/src/main/kotlin/nexters/admin/controller/generation/GenerationController.kt
+++ b/src/main/kotlin/nexters/admin/controller/generation/GenerationController.kt
@@ -1,6 +1,7 @@
 package nexters.admin.controller.generation
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import nexters.admin.service.generation.FindCurrentGeneration
 import nexters.admin.service.generation.GenerationResponse
@@ -18,6 +19,7 @@ class GenerationController(
 ) {
 
     @Operation(summary = "현재 기수 조회")
+    @SecurityRequirement(name = "JWT")
     @GetMapping("/current")
     fun getCurrentGeneration(): ResponseEntity<FindCurrentGeneration> {
         val findCurrentGeneration = generationService.findCurrentGeneration()
@@ -25,6 +27,7 @@ class GenerationController(
     }
 
     @Operation(summary = "전체 기수 조회")
+    @SecurityRequirement(name = "JWT")
     @GetMapping
     fun getAllGenerations(): ResponseEntity<GenerationResponses> {
         val generationResponses = generationService.findAllGeneration()
@@ -32,6 +35,7 @@ class GenerationController(
     }
 
     @Operation(summary = "기수 추가")
+    @SecurityRequirement(name = "JWT")
     @PostMapping
     fun addGeneration(
             @RequestBody @Valid request: CreateGenerationRequest
@@ -41,6 +45,7 @@ class GenerationController(
     }
 
     @Operation(summary = "기수 삭제")
+    @SecurityRequirement(name = "JWT")
     @DeleteMapping("/{generation}")
     fun removeGeneration(
             @PathVariable generation: Int,
@@ -50,6 +55,7 @@ class GenerationController(
     }
 
     @Operation(summary = "기수 수정")
+    @SecurityRequirement(name = "JWT")
     @PutMapping("/{generation}")
     fun updateGeneration(
             @PathVariable generation: Int,
@@ -60,6 +66,7 @@ class GenerationController(
     }
 
     @Operation(summary = "기수 상세조회")
+    @SecurityRequirement(name = "JWT")
     @GetMapping("/{generation}")
     fun getGenerationDetail(
             @PathVariable generation: Int,

--- a/src/main/kotlin/nexters/admin/controller/generation/GenerationDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/generation/GenerationDtos.kt
@@ -1,0 +1,9 @@
+package nexters.admin.controller.generation
+
+data class CreateGenerationRequest(
+        val generation: Int,
+)
+
+data class UpdateGenerationRequest(
+        val status: String,
+)

--- a/src/main/kotlin/nexters/admin/domain/generation/Generation.kt
+++ b/src/main/kotlin/nexters/admin/domain/generation/Generation.kt
@@ -5,14 +5,14 @@ import javax.persistence.*
 @Entity
 @Table(name = "generation")
 class Generation(
-        @Column(unique = true)
-        var generation: Long = 0L,
+        @Column(name = "generation", unique = true, nullable = false)
+        var generation: Int,
 
-        @Column
+        @Column(name = "ceo")
         var ceo: String? = null,
 
         @Enumerated(EnumType.STRING)
-        @Column
+        @Column(name = "status")
         var status: GenerationStatus = GenerationStatus.BEFORE_ACTIVITY,
 ) {
         @Id

--- a/src/main/kotlin/nexters/admin/domain/generation/Generation.kt
+++ b/src/main/kotlin/nexters/admin/domain/generation/Generation.kt
@@ -8,9 +8,6 @@ class Generation(
         @Column(name = "generation", unique = true, nullable = false)
         var generation: Int,
 
-        @Column(name = "ceo")
-        var ceo: String? = null,
-
         @Enumerated(EnumType.STRING)
         @Column(name = "status")
         var status: GenerationStatus = GenerationStatus.BEFORE_ACTIVITY,

--- a/src/main/kotlin/nexters/admin/domain/generation/GenerationStatus.kt
+++ b/src/main/kotlin/nexters/admin/domain/generation/GenerationStatus.kt
@@ -4,7 +4,7 @@ import nexters.admin.exception.BadRequestException
 
 enum class GenerationStatus(val value: String?) {
     BEFORE_ACTIVITY("활동 준비"),
-    DURING_ACTIVITY("활동중"),
+    DURING_ACTIVITY("활동 중"),
     FINISH_ACTIVITY("활동 종료"),
     NULL("")
     ;

--- a/src/main/kotlin/nexters/admin/exception/CustomExceptions.kt
+++ b/src/main/kotlin/nexters/admin/exception/CustomExceptions.kt
@@ -3,6 +3,7 @@ package nexters.admin.exception
 class BadRequestException(message: String?) : RuntimeException(message) {
     companion object {
         fun alreadyExistsAdministrator() = BadRequestException("이미 존재하는 관리자 아이디입니다.")
+        fun existsGenerationMembers() = BadRequestException("기수회원이 존재하는 기수는 삭제할 수 없습니다.")
         fun wrongGender() = BadRequestException("올바르지 않은 성별입니다.")
         fun wrongPosition() = BadRequestException("올바르지 않은 직군입니다.")
         fun wrongMemberStatus() = BadRequestException("올바르지 않은 활동구분입니다.")

--- a/src/main/kotlin/nexters/admin/repository/GenerationMemberRepository.kt
+++ b/src/main/kotlin/nexters/admin/repository/GenerationMemberRepository.kt
@@ -1,7 +1,6 @@
 package nexters.admin.repository
 
 import nexters.admin.domain.generation_member.GenerationMember
-import nexters.admin.domain.user.member.Member
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface GenerationMemberRepository : JpaRepository<GenerationMember, Long> {
@@ -9,4 +8,5 @@ interface GenerationMemberRepository : JpaRepository<GenerationMember, Long> {
     fun findByGenerationAndMemberId(generation: Int, memberId: Long): GenerationMember?
     fun findTopByMemberIdOrderByGenerationDesc(memberId: Long): GenerationMember?
     fun findAllByMemberIdIn(memberIds: List<Long>): List<GenerationMember>
+    fun findByGeneration(generation: Int): List<GenerationMember>
 }

--- a/src/main/kotlin/nexters/admin/repository/GenerationRepository.kt
+++ b/src/main/kotlin/nexters/admin/repository/GenerationRepository.kt
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface GenerationRepository : JpaRepository<Generation, Long> {
     fun findFirstByOrderByGenerationDesc(): Generation?
-    fun deleteByGeneration(generation: Long)
-    fun findByGeneration(generation: Long): Generation?
+    fun deleteByGeneration(generation: Int)
+    fun findByGeneration(generation: Int): Generation?
 }

--- a/src/main/kotlin/nexters/admin/repository/MemberRepository.kt
+++ b/src/main/kotlin/nexters/admin/repository/MemberRepository.kt
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<Member, Long> {
     fun findByEmail(email: String): Member?
+    fun findByName(name: String): Member?
     fun findAllByEmailIn(emails: List<String>): List<Member>
 }

--- a/src/main/kotlin/nexters/admin/service/generation/GenerationDtos.kt
+++ b/src/main/kotlin/nexters/admin/service/generation/GenerationDtos.kt
@@ -4,7 +4,7 @@ import nexters.admin.domain.generation.Generation
 import nexters.admin.domain.generation.GenerationStatus
 
 data class CreateGenerationRequest(
-        val generation: Long,
+        val generation: Int,
         val ceo: String,
 )
 
@@ -14,9 +14,9 @@ data class UpdateGenerationRequest(
 )
 
 data class GenerationResponse(
-        val generation: Long,
+        val generation: Int,
         val ceo: String?,
-        val status: GenerationStatus
+        val status: GenerationStatus,
 ) {
     companion object {
         fun from(generation: Generation): GenerationResponse {

--- a/src/main/kotlin/nexters/admin/service/generation/GenerationDtos.kt
+++ b/src/main/kotlin/nexters/admin/service/generation/GenerationDtos.kt
@@ -3,28 +3,25 @@ package nexters.admin.service.generation
 import nexters.admin.domain.generation.Generation
 import nexters.admin.domain.generation.GenerationStatus
 
-data class CreateGenerationRequest(
-        val generation: Int,
-        val ceo: String,
-)
-
-data class UpdateGenerationRequest(
-        val ceo: String,
-        val status: GenerationStatus
+data class GenerationResponses(
+        val data: List<GenerationResponse?>,
 )
 
 data class GenerationResponse(
         val generation: Int,
-        val ceo: String?,
         val status: GenerationStatus,
 ) {
     companion object {
         fun from(generation: Generation): GenerationResponse {
             return GenerationResponse(
                     generation = generation.generation,
-                    ceo = generation.ceo,
                     status = generation.status
             )
         }
     }
 }
+
+data class FindCurrentGeneration(
+        val generation: Int,
+        val status: GenerationStatus,
+)

--- a/src/main/kotlin/nexters/admin/service/generation/GenerationService.kt
+++ b/src/main/kotlin/nexters/admin/service/generation/GenerationService.kt
@@ -5,8 +5,10 @@ import nexters.admin.exception.BadRequestException
 import nexters.admin.exception.NotFoundException
 import nexters.admin.repository.GenerationRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional
 class GenerationService(
         private val generationRepository: GenerationRepository
 ) {
@@ -23,11 +25,11 @@ class GenerationService(
         )
     }
 
-    fun deleteGeneration(generation: Long) {
+    fun deleteGeneration(generation: Int) {
         generationRepository.deleteByGeneration(generation)
     }
 
-    fun updateGeneration(generation: Long, request: UpdateGenerationRequest) {
+    fun updateGeneration(generation: Int, request: UpdateGenerationRequest) {
         val found = generationRepository.findByGeneration(generation) ?: throw NotFoundException.generationNotFound()
         found.apply {
             ceo = request.ceo
@@ -36,15 +38,18 @@ class GenerationService(
         generationRepository.save(found)
     }
 
-    fun findGeneration(generation: Long): Generation {
+    @Transactional(readOnly = true)
+    fun findGeneration(generation: Int): Generation {
         return generationRepository.findByGeneration(generation) ?: throw NotFoundException.generationNotFound()
     }
 
+    @Transactional(readOnly = true)
     fun findAllGeneration(): List<Generation> {
         return generationRepository.findAll()
     }
 
     // TODO: MAX(generation) 사용하도록 수정
+    @Transactional(readOnly = true)
     fun findCurrentGeneration(): Generation {
         return generationRepository.findFirstByOrderByGenerationDesc() ?: throw NotFoundException.generationNotFound()
     }

--- a/src/test/kotlin/nexters/admin/acceptance/GenerationAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/admin/acceptance/GenerationAcceptanceTest.kt
@@ -1,0 +1,48 @@
+package nexters.admin.acceptance
+
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import nexters.admin.controller.generation.CreateGenerationRequest
+import nexters.admin.testsupport.AcceptanceTest
+import nexters.admin.testsupport.generateCreateMemberRequest
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+
+class GenerationAcceptanceTest : AcceptanceTest() {
+
+    @Test
+    fun `관리자는 기수를 추가할 수 있다`() {
+        val adminToken = 관리자_생성_토큰_발급()
+
+        Given {
+            log().all()
+            contentType(MediaType.APPLICATION_JSON_VALUE)
+            auth().oauth2(adminToken)
+            body(CreateGenerationRequest(22))
+        } When {
+            post("/api/generation")
+        } Then {
+            statusCode(200)
+        }
+    }
+
+    @Test
+    fun `일반 회원은 기수를 추가할 수 없다`() {
+        val adminToken = 관리자_생성_토큰_발급()
+        val request = generateCreateMemberRequest()
+        회원_생성(adminToken, request)
+        val memberToken = 회원_로그인_토큰(request.email, "12345678")
+
+        Given {
+            log().all()
+            contentType(MediaType.APPLICATION_JSON_VALUE)
+            auth().oauth2(memberToken)
+            body(CreateGenerationRequest(22))
+        } When {
+            post("/api/generation")
+        } Then {
+            statusCode(403)
+        }
+    }
+}

--- a/src/test/kotlin/nexters/admin/acceptance/MemberAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/admin/acceptance/MemberAcceptanceTest.kt
@@ -55,7 +55,7 @@ class MemberAcceptanceTest : AcceptanceTest() {
 
         val response = Given {
             log().all()
-            header("Authorization", "Bearer $memberToken")
+            auth().oauth2(memberToken)
             contentType(MediaType.APPLICATION_JSON_VALUE)
         } When {
             get("/api/members/me")

--- a/src/test/kotlin/nexters/admin/service/attendance/AttendanceServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/attendance/AttendanceServiceTest.kt
@@ -13,11 +13,13 @@ import nexters.admin.domain.user.member.Member
 import nexters.admin.exception.BadRequestException
 import nexters.admin.repository.AttendanceRepository
 import nexters.admin.repository.GenerationMemberRepository
+import nexters.admin.repository.GenerationRepository
 import nexters.admin.repository.MemberRepository
 import nexters.admin.repository.QrCodeRepository
 import nexters.admin.repository.SessionRepository
 import nexters.admin.testsupport.ApplicationTest
 import nexters.admin.testsupport.createNewAttendance
+import nexters.admin.testsupport.createNewGeneration
 import nexters.admin.testsupport.createNewGenerationMember
 import nexters.admin.testsupport.createNewMember
 import nexters.admin.testsupport.createNewSession
@@ -38,9 +40,11 @@ class AttendanceServiceTest(
         @Autowired private val sessionRepository: SessionRepository,
         @Autowired private val memberRepository: MemberRepository,
         @Autowired private val qrCodeRepository: QrCodeRepository,
+        @Autowired private val generationRepository: GenerationRepository,
 ) {
     @Test
     fun `내 출석정보 조회`() {
+        generationRepository.save(createNewGeneration())
         val member: Member = memberRepository.save(createNewMember())
         val generationMember: GenerationMember = generationMemberRepository
                 .save(createNewGenerationMember(memberId = member.id))
@@ -64,6 +68,7 @@ class AttendanceServiceTest(
 
     @Test
     fun `내 출석정보 조회시 PENDING이 아닌 정보들만 불러온다`() {
+        generationRepository.save(createNewGeneration())
         val member: Member = memberRepository.save(createNewMember())
         val generationMember: GenerationMember = generationMemberRepository
                 .save(createNewGenerationMember(memberId = member.id))
@@ -91,6 +96,7 @@ class AttendanceServiceTest(
 
     @Test
     fun `내 출석정보 조회시 해당 기수의 멤버가 아니면 기수확인 속성은 false을, 데이터는 null을 반환한다`() {
+        generationRepository.save(createNewGeneration())
         val member: Member = memberRepository.save(createNewMember())
 
         val attendanceProfile = attendanceService.getAttendanceProfile(member)
@@ -101,6 +107,7 @@ class AttendanceServiceTest(
 
     @Test
     fun `내 출석정보 조회시 week 순으로 내림차순해서 반환한다`() {
+        generationRepository.save(createNewGeneration())
         val member: Member = memberRepository.save(createNewMember())
         val generationMember: GenerationMember = generationMemberRepository
                 .save(createNewGenerationMember(memberId = member.id))
@@ -125,6 +132,7 @@ class AttendanceServiceTest(
     @ParameterizedTest
     @EnumSource(AttendanceStatus::class, mode = EXCLUDE, names = ["PENDING"])
     fun `내 출석정보 조회시 출석상태에 맞는 점수를 반환한다`(attendanceStatus: AttendanceStatus) {
+        generationRepository.save(createNewGeneration())
         val member: Member = memberRepository.save(createNewMember())
         val generationMember: GenerationMember = generationMemberRepository
                 .save(createNewGenerationMember(memberId = member.id))
@@ -158,6 +166,7 @@ class AttendanceServiceTest(
 
     @Test
     fun `유효한 QR 코드로 출석 성공시 출석 상태 수정`() {
+        generationRepository.save(createNewGeneration())
         val member = memberRepository.save(createNewMember())
         val generationMember = generationMemberRepository
                 .save(createNewGenerationMember(memberId = member.id))
@@ -173,6 +182,7 @@ class AttendanceServiceTest(
 
     @Test
     fun `출석 체크 종료 이후에 PENDING 상태의 출석은 모두 무단 결석으로 처리`() {
+        generationRepository.save(createNewGeneration())
         val member = memberRepository.save(createNewMember())
         val generationMember = generationMemberRepository
                 .save(createNewGenerationMember(memberId = member.id))
@@ -189,6 +199,7 @@ class AttendanceServiceTest(
 
     @Test
     fun `잘못된 QR 코드로 출석 시도시, 예외 발생`() {
+        generationRepository.save(createNewGeneration())
         val member = memberRepository.save(createNewMember())
         qrCodeRepository.initializeCodes(1L, AttendanceStatus.ATTENDED)
 
@@ -199,6 +210,7 @@ class AttendanceServiceTest(
 
     @Test
     fun `현재 활동기수가 아닌 회원이 QR 코드로 출석 시도시, 예외 발생`() {
+        generationRepository.save(createNewGeneration())
         val member = memberRepository.save(createNewMember())
         val session = sessionRepository.save(createNewSession())
         qrCodeRepository.initializeCodes(session.id, AttendanceStatus.TARDY)

--- a/src/test/kotlin/nexters/admin/service/generation/GenerationServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/generation/GenerationServiceTest.kt
@@ -1,0 +1,101 @@
+package nexters.admin.service.generation
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import nexters.admin.controller.generation.CreateGenerationRequest
+import nexters.admin.controller.generation.UpdateGenerationRequest
+import nexters.admin.domain.generation.GenerationStatus
+import nexters.admin.exception.BadRequestException
+import nexters.admin.repository.GenerationMemberRepository
+import nexters.admin.repository.GenerationRepository
+import nexters.admin.testsupport.ApplicationTest
+import nexters.admin.testsupport.createNewGenerationMember
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+@ApplicationTest
+class GenerationServiceTest(
+        @Autowired private val generationService: GenerationService,
+        @Autowired private val generationRepository: GenerationRepository,
+        @Autowired private val generationMemberRepository: GenerationMemberRepository,
+) {
+
+    @Test
+    fun `기수를 생성한다`() {
+        generationService.run { createGeneration(CreateGenerationRequest(22)) }
+
+        val generation = generationRepository.findByGeneration(22)
+        generation?.generation shouldBe 22
+        generation?.status shouldBe GenerationStatus.BEFORE_ACTIVITY
+    }
+
+    @Test
+    fun `특정 기수를 조회한다`() {
+        generationService.run { createGeneration(CreateGenerationRequest(21)) }
+        generationService.run { createGeneration(CreateGenerationRequest(22)) }
+
+        val generation = generationService.findGeneration(22)
+        generation.generation shouldBe 22
+        generation.status shouldBe GenerationStatus.BEFORE_ACTIVITY
+    }
+
+    @Test
+    fun `전체 기수를 조회한다`() {
+        generationService.run { createGeneration(CreateGenerationRequest(21)) }
+        generationService.run { createGeneration(CreateGenerationRequest(22)) }
+
+        val generations = generationService.findAllGeneration()
+
+        generations.data shouldHaveSize 2
+    }
+
+    @Test
+    fun `현재 기수를 조회한다`() {
+        generationService.run { createGeneration(CreateGenerationRequest(21)) }
+        generationService.run { createGeneration(CreateGenerationRequest(22)) }
+
+        val generation = generationService.findCurrentGeneration()
+
+        generation.generation shouldBe 22
+    }
+
+    @Test
+    fun `기수 정보를 변경한다`() {
+        generationService.run { createGeneration(CreateGenerationRequest(22)) }
+
+        generationService.updateGeneration(22, UpdateGenerationRequest(GenerationStatus.DURING_ACTIVITY.value!!))
+
+        val generation = generationRepository.findByGeneration(22)
+        generation?.status shouldBe GenerationStatus.DURING_ACTIVITY
+    }
+
+    @Test
+    fun `잘못된 활동정보로 기수 정보를 변경하면 예외를 반환한다`() {
+        generationService.run { createGeneration(CreateGenerationRequest(22)) }
+
+        shouldThrow<BadRequestException> {
+            generationService.updateGeneration(22, UpdateGenerationRequest("김태현의 활동"))
+        }
+    }
+
+    @Test
+    fun `기수회원이 없는 기수를 삭제한다`() {
+        generationService.run { createGeneration(CreateGenerationRequest(22)) }
+
+        generationService.deleteGeneration(22)
+
+        val generation = generationRepository.findByGeneration(22)
+        generation shouldBe null
+    }
+
+    @Test
+    fun `기수회원이 있는 기수를 삭제하면 예외를 반환한다`() {
+        generationService.run { createGeneration(CreateGenerationRequest(22)) }
+        generationMemberRepository.save(createNewGenerationMember())
+
+        shouldThrow<BadRequestException> {
+            generationService.deleteGeneration(22)
+        }
+    }
+}

--- a/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
@@ -3,11 +3,10 @@ package nexters.admin.service.user
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import nexters.admin.testsupport.PHONE_NUMBER
 import nexters.admin.controller.user.CreateMemberRequest
 import nexters.admin.controller.user.UpdateMemberRequest
-import nexters.admin.testsupport.createNewGenerationMember
-import nexters.admin.testsupport.createNewMember
+import nexters.admin.domain.generation.Generation
+import nexters.admin.domain.generation.GenerationStatus
 import nexters.admin.domain.generation_member.GenerationMember
 import nexters.admin.domain.generation_member.Position
 import nexters.admin.domain.generation_member.SubPosition
@@ -16,8 +15,12 @@ import nexters.admin.domain.user.member.Member
 import nexters.admin.domain.user.member.MemberStatus
 import nexters.admin.exception.NotFoundException
 import nexters.admin.repository.GenerationMemberRepository
+import nexters.admin.repository.GenerationRepository
 import nexters.admin.repository.MemberRepository
 import nexters.admin.testsupport.ApplicationTest
+import nexters.admin.testsupport.PHONE_NUMBER
+import nexters.admin.testsupport.createNewGenerationMember
+import nexters.admin.testsupport.createNewMember
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
@@ -27,6 +30,7 @@ class MemberServiceTest(
         @Autowired private val memberService: MemberService,
         @Autowired private val memberRepository: MemberRepository,
         @Autowired private val generationMemberRepository: GenerationMemberRepository,
+        @Autowired private val generationRepository: GenerationRepository,
 ) {
     @Test
     fun `회원 저장`() {
@@ -117,6 +121,8 @@ class MemberServiceTest(
 
     @Test
     fun `회원 복수 생성시 엑셀 정보를 토대로 회원과 기수 회원 모두 생성`() {
+        createLatestGeneration(21)
+
         val generation = 22L
         val excelInput = mutableMapOf(
                 "name" to mutableListOf("정진우", "김민수", "최다예"),
@@ -140,6 +146,8 @@ class MemberServiceTest(
 
     @Test
     fun `회원 복수 생성시 이메일을 기준으로 이미 생성된 회원 정보는 이메일을 그대로 덮어씌어짐`() {
+        createLatestGeneration(21)
+
         val generation = 22
         val excelInput = mutableMapOf(
                 "name" to mutableListOf("정진우", "김민수", "최다예"),
@@ -163,6 +171,8 @@ class MemberServiceTest(
 
     @Test
     fun `회원 복수 생성시 이메일과 기수 정보를 기준으로 이미 생성된 기수회원의 직군 정보만 그대로 덮어씌어짐`() {
+        createLatestGeneration(21)
+
         val generation = 22
         val excelInput = mutableMapOf(
                 "name" to mutableListOf("정진우", "김민수", "최다예"),
@@ -185,6 +195,10 @@ class MemberServiceTest(
         generationMemberRepository.findByIdOrNull(existingMatchingGenerationMember.id)?.position shouldBe Position.DEVELOPER
         memberRepository.findAll() shouldHaveSize 3
         generationMemberRepository.findAll() shouldHaveSize 4
+    }
+
+    private fun createLatestGeneration(generation: Int) {
+        generationRepository.save(Generation(generation, GenerationStatus.FINISH_ACTIVITY))
     }
 
     @Test

--- a/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
@@ -4,6 +4,8 @@ import nexters.admin.controller.user.CreateMemberRequest
 import nexters.admin.domain.attendance.Attendance
 import nexters.admin.domain.attendance.AttendanceStatus
 import nexters.admin.domain.attendance.QrCode
+import nexters.admin.domain.generation.Generation
+import nexters.admin.domain.generation.GenerationStatus
 import nexters.admin.domain.generation_member.GenerationMember
 import nexters.admin.domain.generation_member.Position
 import nexters.admin.domain.generation_member.SubPosition
@@ -89,7 +91,14 @@ fun createNewQrCode(
         sessionId: Long = 1L,
         value: String = "ASDFGH",
         attendanceType: AttendanceStatus = AttendanceStatus.ATTENDED,
-        expirationTime: LocalDateTime = LocalDateTime.now().plusSeconds(60)
+        expirationTime: LocalDateTime = LocalDateTime.now().plusSeconds(60),
 ): QrCode {
     return QrCode(sessionId, value, attendanceType, expirationTime)
+}
+
+fun createNewGeneration(
+        generation: Int = 22,
+        status: String = "활동 중",
+): Generation {
+    return Generation(generation, GenerationStatus.from(status))
 }


### PR DESCRIPTION
close #46 

- Swagger에서 관리자 계정으로 기수 생성 시 401 에러 뜨던 버그 수정 (`@SecurityRequirement(name = "JWT")` 누락)
- 세션, 기수 쪽에서 DTO를 반환하도록 변경
- 기수 쪽 테스트 코드 작성
- 기수 정보에서 ceo 정보 삭제
- 회원 복수 생성 시, 기수를 자동으로 최신기수+1 정보로 추가하도록
- 기수 삭제 시, 기수회원이 남아있으면 삭제하지 못하도록 변경