### PR TITLE
fix: 회원 복수 생성 시, 기수가 이미 있으면 중복생성하지 않도록 수정

### DIFF
--- a/src/main/kotlin/nexters/admin/controller/user/MemberController.kt
+++ b/src/main/kotlin/nexters/admin/controller/user/MemberController.kt
@@ -33,7 +33,7 @@ class MemberController(
     @SecurityRequirement(name = "JWT")
     @PostMapping(value = ["/bulk"], consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun createMembersByAdministrator(
-            @RequestParam generation: Long,
+            @RequestParam generation: Int,
             @RequestParam csvFile: MultipartFile,
     ): ResponseEntity<Void> {
         memberService.createGenerationMembers(generation, parseCsvFileToMap(csvFile))

--- a/src/main/kotlin/nexters/admin/domain/generation_member/GenerationMembers.kt
+++ b/src/main/kotlin/nexters/admin/domain/generation_member/GenerationMembers.kt
@@ -17,7 +17,7 @@ class GenerationMembers(
 ) {
     companion object {
         fun of(
-                generation: Long,
+                generation: Int,
                 generationMembers: Map<String, List<String>>,
                 savedMembers: List<Member>,
         ): GenerationMembers {
@@ -32,7 +32,7 @@ class GenerationMembers(
                 val memberId = emailToMemberIdMap[email] ?: throw RuntimeException("wrong implementation")
                 values[memberId] = (GenerationMember(
                         memberId = memberId,
-                        generation = generation.toInt(),
+                        generation = generation,
                         position = generationMembers[POSITION]?.get(idx)?.let { Position.from(it) }
                                 ?: throw BadRequestException.missingInfo("회원의 직군"),
                         subPosition = generationMembers[SUB_POSITION]?.get(idx)?.let { SubPosition.from(it) }

--- a/src/main/kotlin/nexters/admin/service/user/MemberService.kt
+++ b/src/main/kotlin/nexters/admin/service/user/MemberService.kt
@@ -72,8 +72,9 @@ class MemberService(
                 }
     }
 
-    fun createGenerationMembers(generation: Long, memberMap: Map<String, List<String>>) {
-        createNewGeneration()
+    fun createGenerationMembers(generation: Int, memberMap: Map<String, List<String>>) {
+        generationRepository.findByGeneration(generation)
+                ?: generationService.createGeneration(CreateGenerationRequest(generation))
 
         val members = Members.of(memberMap)
         val existingMembers = memberRepository.findAllByEmailIn(members.getEmails())
@@ -86,13 +87,6 @@ class MemberService(
         val existingGenerationMembers = generationMemberRepository.findAllByMemberIdIn(savedMembers.map { it.id })
         generationMembers.updateGenerationMembersWithMatchingMemberId(existingGenerationMembers)
         generationMemberRepository.saveAll(generationMembers.findAllByMemberIdsNotIn(existingGenerationMembers.map { it.memberId }))
-    }
-
-    private fun createNewGeneration() {
-        val latestGeneration = (generationRepository.findFirstByOrderByGenerationDesc()
-                ?.generation
-                ?: throw NotFoundException.generationNotFound())
-        generationService.createGeneration(CreateGenerationRequest(latestGeneration + 1))
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
close #56 

GenerationMember 에서 generation 대신 generation_id를 갖게 하려 했으나, 변경영향이 지나치게 커서 보류.
(repository method 바뀌며, generationId를 가지면 generation 순 정렬하는거 불가능하므로 generation에 조인치고 바껴야되고, 서비스도 바뀌고 GenerationMembers 도메인도 바뀌고 등등...)

그 외에 `회원 복수 생성 시, 파라미터로 넘겨지는 generation에 해당되는 기수를 생성하도록 한다. 단, 두 번 이상 bulk 생성할 경우 기수는 별도로 생성하지 않도록 한다.`, `generation을 Long이 아닌 Int 타입으로 변경`는 완료