### PR TITLE
fix: session 도메인 일부 칼럼 not null 처리 및 새로운 세션 생성시 회원 출석 정보 생성

### DIFF
--- a/src/main/kotlin/nexters/admin/controller/session/SessionDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/session/SessionDtos.kt
@@ -5,7 +5,6 @@ import java.time.LocalDate
 data class CreateSessionRequest(
         val title: String,
         val description: String?,
-        val message: String?,
         val generation: Int,
         val sessionTime: LocalDate,
         val week: Int,
@@ -14,7 +13,6 @@ data class CreateSessionRequest(
 data class UpdateSessionRequest(
         val title: String,
         val description: String?,
-        val message: String?,
         val generation: Int,
         val sessionTime: LocalDate,
         val week: Int,

--- a/src/main/kotlin/nexters/admin/domain/session/Session.kt
+++ b/src/main/kotlin/nexters/admin/domain/session/Session.kt
@@ -13,9 +13,6 @@ class Session(
         @Column(name = "description")
         var description: String? = null,
 
-        @Column(name = "message")
-        var message: String? = null,
-
         @Column(name = "generation", nullable = false)
         var generation: Int,
 

--- a/src/main/kotlin/nexters/admin/domain/session/Session.kt
+++ b/src/main/kotlin/nexters/admin/domain/session/Session.kt
@@ -2,13 +2,18 @@ package nexters.admin.domain.session
 
 import java.time.LocalDate
 import java.time.LocalDateTime
-import javax.persistence.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
 
 @Entity
 @Table(name = "session")
 class Session(
-        @Column(name = "title")
-        var title: String? = null,
+        @Column(name = "title", nullable = false)
+        var title: String,
 
         @Column(name = "description")
         var description: String? = null,
@@ -16,8 +21,8 @@ class Session(
         @Column(name = "generation", nullable = false)
         var generation: Int,
 
-        @Column(name = "session_time")
-        var sessionTime: LocalDate? = null,
+        @Column(name = "session_time", nullable = false)
+        var sessionTime: LocalDate,
 
         @Column(name = "week", nullable = false)
         var week: Int,

--- a/src/main/kotlin/nexters/admin/service/session/SessionDtos.kt
+++ b/src/main/kotlin/nexters/admin/service/session/SessionDtos.kt
@@ -59,11 +59,11 @@ data class FindSessionHomeResponse(
 }
 
 data class SessionHomeResponse(
-        val sessionDate: LocalDate?,
-        val title: String?,
+        val sessionDate: LocalDate,
+        val title: String,
         val description: String?,
-        val sessionStatus: SessionStatus?,
-        val attendanceStatus: AttendanceStatus?,
+        val sessionStatus: SessionStatus,
+        val attendanceStatus: AttendanceStatus,
         val attendanceTime: LocalDateTime?,
 ) {
     companion object {

--- a/src/main/kotlin/nexters/admin/service/session/SessionDtos.kt
+++ b/src/main/kotlin/nexters/admin/service/session/SessionDtos.kt
@@ -61,6 +61,7 @@ data class FindSessionHomeResponse(
 data class SessionHomeResponse(
         val sessionDate: LocalDate,
         val title: String,
+        val week: Int,
         val description: String?,
         val sessionStatus: SessionStatus,
         val attendanceStatus: AttendanceStatus,
@@ -71,6 +72,7 @@ data class SessionHomeResponse(
             return SessionHomeResponse(
                     session.sessionTime,
                     session.title,
+                    session.week,
                     session.description,
                     findSessionStatus(session),
                     attendance.attendanceStatus,

--- a/src/main/kotlin/nexters/admin/service/session/SessionService.kt
+++ b/src/main/kotlin/nexters/admin/service/session/SessionService.kt
@@ -37,7 +37,6 @@ class SessionService(
                 Session(
                         title = request.title,
                         description = request.description,
-                        message = request.message,
                         generation = request.generation,
                         sessionTime = request.sessionTime,
                         week = request.week,
@@ -61,7 +60,6 @@ class SessionService(
         session.apply {
             title = request.title
             description = request.description
-            message = request.message
             generation = request.generation
             sessionTime = request.sessionTime
             week = request.week

--- a/src/main/kotlin/nexters/admin/service/session/SessionService.kt
+++ b/src/main/kotlin/nexters/admin/service/session/SessionService.kt
@@ -2,6 +2,8 @@ package nexters.admin.service.session
 
 import nexters.admin.controller.session.CreateSessionRequest
 import nexters.admin.controller.session.UpdateSessionRequest
+import nexters.admin.domain.attendance.Attendance
+import nexters.admin.domain.attendance.AttendanceStatus.PENDING
 import nexters.admin.domain.session.Session
 import nexters.admin.domain.user.member.Member
 import nexters.admin.exception.NotFoundException
@@ -42,6 +44,15 @@ class SessionService(
                         week = request.week,
                 )
         )
+        val generationMembers = generationMemberRepository.findByGeneration(request.generation)
+        val attendances = generationMembers.map {
+            Attendance(
+                    generationMemberId = it.id,
+                    sessionId = savedSession.id,
+                    attendanceStatus = PENDING
+            )
+        }
+        attendanceRepository.saveAll(attendances)
 
         return savedSession.id
     }

--- a/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
@@ -39,7 +39,6 @@ class SessionServiceTest(
                 CreateSessionRequest(
                         title = "Test title",
                         description = "Test description",
-                        message = "Test message",
                         generation = 22,
                         sessionTime = LocalDate.now(),
                         week = 3,
@@ -58,7 +57,6 @@ class SessionServiceTest(
                 CreateSessionRequest(
                         title = "Test title",
                         description = null,
-                        message = null,
                         generation = 22,
                         sessionTime = LocalDate.now(),
                         week = 3,
@@ -116,7 +114,6 @@ class SessionServiceTest(
         sessionService.updateSession(session.id, UpdateSessionRequest(
                 title = "Updated Title",
                 description = "Test description",
-                message = "Test message",
                 generation = 22,
                 sessionTime = LocalDate.now(),
                 week = 3,

--- a/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/session/SessionServiceTest.kt
@@ -13,6 +13,7 @@ import nexters.admin.repository.AttendanceRepository
 import nexters.admin.repository.GenerationMemberRepository
 import nexters.admin.repository.MemberRepository
 import nexters.admin.repository.SessionRepository
+import nexters.admin.repository.findAllPendingAttendanceOf
 import nexters.admin.testsupport.ApplicationTest
 import nexters.admin.testsupport.createNewAttendance
 import nexters.admin.testsupport.createNewGenerationMember
@@ -68,6 +69,32 @@ class SessionServiceTest(
         found shouldNotBe null
         found?.title shouldBe "Test title"
         found?.description shouldBe null
+    }
+
+    @Test
+    fun `세션 생성시 기수 회원들의 PENDING 상태 출석 정보를 생성한다`() {
+        val member1 = createNewMember()
+        val member2 = createNewMember()
+        memberRepository.saveAll(listOf(member1, member2))
+        val generationMember1 = createNewGenerationMember(memberId = member1.id, generation = 22)
+        val generationMember2 = createNewGenerationMember(memberId = member2.id, generation = 22)
+        val generationMember3 = createNewGenerationMember(memberId = member2.id, generation = 23)
+        generationMemberRepository.saveAll(listOf(generationMember1, generationMember2, generationMember3))
+        val savedSessionId = sessionService.createSession(
+                CreateSessionRequest(
+                        title = "Test title",
+                        description = null,
+                        generation = 22,
+                        sessionTime = LocalDate.now(),
+                        week = 3,
+                )
+        )
+
+        val attendances = attendanceRepository.findAllPendingAttendanceOf(sessionId = savedSessionId)
+        attendances.size shouldBe 2
+        attendances.forEach {
+            it.sessionId shouldBe savedSessionId
+        }
     }
 
     @Test

--- a/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
@@ -66,16 +66,15 @@ fun createNewAdmin(
 }
 
 fun createNewSession(
-        title: String = "1주차 세션",
-        description: String = "OT & 팀빌딩",
-        message: String = "오늘은 설레는 첫 세션 날이에요!",
+        title: String = "OT",
+        description: String = "오늘은 설레는 첫 세션 날이에요!",
         generation: Int = 22,
         sessionTime: LocalDate = LocalDate.of(2023, 1, 7),
         week: Int = 1,
         startAttendTime: LocalDateTime? = LocalDateTime.of(2023, 1, 7, 14, 0),
         endAttendTime: LocalDateTime? = LocalDateTime.of(2023, 1, 7, 14, 5),
 ): Session {
-    return Session(title, description, message, generation, sessionTime, week, startAttendTime, endAttendTime)
+    return Session(title, description, generation, sessionTime, week, startAttendTime, endAttendTime)
 }
 
 fun createNewAttendance(


### PR DESCRIPTION
### 관련 이슈
- #55 
- #57 

### 변경사항
- Session 도메인의 title / sessionTime 속성에 대해 `nullable=false` 처리 해줬습니다.
- 세션 홈 조회 응답값에 sessionDate / title / sessionStatus / attendanceStatus 속성에 대해 not null 처리 했습니다.
- 세션 홈 조회 응답값에 week 속성을 추가했습니다.

### 추가로 논의하고싶은 사항
- 세션 정보 생성 후 새롭게 추가되는 기수 회원의 경우 출석 정보가 존재하지 않게 됩니다.
- 운영진이 신입 기수 회원 모집 전 미리 세션 정보를 등록하는 경우가 있을 것 같습니다.
- 따라서 SessionStatus에서 아예 PENDING을 없애는 방법에 대해 논의해보고 싶습니다.
1. 회원 출석시 `출석` 상태의 출석 정보가 생성됩니다.
2. 출석 종료시 `무단 결석` 상태의 출석 정보가 생성됩니다.
3. 운영진이 특정 회원에 대해 통보 결석 설정시 `통보 결석` 상태의 출석 정보가 생성됩니다.
4. 어드민 페이지의 출석 관리 페이지에선, generationMember 정보와 attendance 정보를 가져와 attendance 정보가 없는 기수 회원들에 대해 "PENDING"상태로 보여줍니다.