### PR TITLE
feat: 출결 상태 수정 API 구현 및 출석 점수 자동 업데이트 구현

### DIFF
--- a/src/main/kotlin/nexters/admin/controller/attendance/AttendanceController.kt
+++ b/src/main/kotlin/nexters/admin/controller/attendance/AttendanceController.kt
@@ -30,6 +30,17 @@ class AttendanceController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "[관리자 페이지] 개인의 출석 상태 수정")
+    @SecurityRequirement(name = "JWT")
+    @PutMapping("/{id}/status")
+    fun updateAttendanceStatus(
+            @PathVariable id: Long,
+            @RequestBody @Valid request: UpdateAttendanceStatusRequest
+    ): ResponseEntity<Void> {
+        attendanceService.updateAttendanceStatusByAdministrator(id, request.attendanceStatus, request.note)
+        return ResponseEntity.ok().build()
+    }
+
     @Operation(summary = "내 출석 정보 조회")
     @SecurityRequirement(name = "JWT")
     @GetMapping("/me")

--- a/src/main/kotlin/nexters/admin/controller/attendance/AttendanceController.kt
+++ b/src/main/kotlin/nexters/admin/controller/attendance/AttendanceController.kt
@@ -30,6 +30,17 @@ class AttendanceController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "[관리자 페이지] 출석 가산점/감점 부여")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping("/{id}/additional-score")
+    fun addExtraAttendanceScore(
+            @PathVariable id: Long,
+            @RequestBody @Valid request: ExtraAttendanceScoreChangeRequest
+    ): ResponseEntity<Void> {
+        attendanceService.addExtraAttendanceScoreByAdministrator(id, request.extraScoreChange, request.extraScoreNote)
+        return ResponseEntity.ok().build()
+    }
+
     @Operation(summary = "[관리자 페이지] 개인의 출석 상태 수정")
     @SecurityRequirement(name = "JWT")
     @PutMapping("/{id}/status")

--- a/src/main/kotlin/nexters/admin/controller/attendance/AttendanceDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/attendance/AttendanceDtos.kt
@@ -22,6 +22,11 @@ data class CurrentQrCodeResponse(
     }
 }
 
+data class ExtraAttendanceScoreChangeRequest(
+        val extraScoreChange: Int,
+        val extraScoreNote: String?
+)
+
 data class UpdateAttendanceStatusRequest(
         val attendanceStatus: String,
         val note: String?

--- a/src/main/kotlin/nexters/admin/controller/attendance/AttendanceDtos.kt
+++ b/src/main/kotlin/nexters/admin/controller/attendance/AttendanceDtos.kt
@@ -22,6 +22,11 @@ data class CurrentQrCodeResponse(
     }
 }
 
+data class UpdateAttendanceStatusRequest(
+        val attendanceStatus: String,
+        val note: String?
+)
+
 data class InitializeQrCodesRequest(
         val sessionId: Long,
         val qrCodeType: String,

--- a/src/main/kotlin/nexters/admin/domain/attendance/Attendance.kt
+++ b/src/main/kotlin/nexters/admin/domain/attendance/Attendance.kt
@@ -32,8 +32,23 @@ class Attendance(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
 
-    fun updateStatus(attendanceStatus: AttendanceStatus) {
+    fun updateStatusByQr(attendanceStatus: AttendanceStatus) {
+        updateStatusAndScore(attendanceStatus)
         this.attendTime = LocalDateTime.now()
+    }
+
+    fun updateStatusByAdmin(attendanceStatus: AttendanceStatus, note: String?) {
+        updateStatusAndScore(attendanceStatus)
+        this.note = note
+    }
+
+    fun addExtraScore(extraScoreChange: Int, extraScoreNote: String?) {
+        this.scoreChanged += extraScoreChange
+        this.extraScoreNote = extraScoreNote
+    }
+
+    private fun updateStatusAndScore(attendanceStatus: AttendanceStatus) {
+        this.scoreChanged += this.attendanceStatus.calculateScoreChangeTo(attendanceStatus)
         this.attendanceStatus = attendanceStatus
     }
 }

--- a/src/main/kotlin/nexters/admin/domain/attendance/Attendance.kt
+++ b/src/main/kotlin/nexters/admin/domain/attendance/Attendance.kt
@@ -9,15 +9,24 @@ class Attendance(
         @Column(name = "attend_time")
         var attendTime: LocalDateTime? = null,
 
-        @Column(name = "generation_member_id")
+        @Column(name = "generation_member_id", nullable = false)
         val generationMemberId: Long,
 
-        @Column(name = "session_id")
+        @Column(name = "session_id", nullable = false)
         val sessionId: Long,
 
         @Enumerated(EnumType.STRING)
-        @Column(name = "attendance_status")
-        var attendanceStatus: AttendanceStatus
+        @Column(name = "attendance_status", nullable = false)
+        var attendanceStatus: AttendanceStatus,
+
+        @Column(name = "extra_score_note")
+        var extraScoreNote: String? = "",
+
+        @Column(name = "additional_point", nullable = false)
+        var scoreChanged: Int = 0,
+
+        @Column(name = "note")
+        var note: String? = "",
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/nexters/admin/domain/attendance/AttendanceStatus.kt
+++ b/src/main/kotlin/nexters/admin/domain/attendance/AttendanceStatus.kt
@@ -15,4 +15,8 @@ enum class AttendanceStatus(val value: String, val penaltyScore: Int) {
                 .firstOrNull { it.name == name }
                 ?: throw BadRequestException.wrongAttendanceStatus()
     }
+
+    fun calculateScoreChangeTo(targetAttendanceStatus: AttendanceStatus): Int {
+        return targetAttendanceStatus.penaltyScore - this.penaltyScore
+    }
 }

--- a/src/main/kotlin/nexters/admin/domain/generation_member/GenerationMember.kt
+++ b/src/main/kotlin/nexters/admin/domain/generation_member/GenerationMember.kt
@@ -9,6 +9,8 @@ import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
 
+const val MAX_SCORE = 100
+
 @Entity
 @Table(name = "generation_member")
 class GenerationMember(
@@ -27,7 +29,7 @@ class GenerationMember(
         var subPosition: SubPosition?,
 
         @Column(name = "score")
-        var score: Int? = 100,
+        var score: Int? = MAX_SCORE,
 
         @Column(name = "is_completable", nullable = false)
         var isCompletable: Boolean = true,
@@ -39,6 +41,10 @@ class GenerationMember(
     fun updatePosition(position: Position?, subPosition: SubPosition?) {
         this.position = position
         this.subPosition = subPosition
+    }
+
+    fun updateScoreByChanges(changedScores: List<Int>) {
+        this.score = changedScores.fold(MAX_SCORE) { totalScore, scoreChange -> totalScore + scoreChange }
     }
 
     fun isManager(): Boolean {

--- a/src/main/kotlin/nexters/admin/exception/CustomExceptions.kt
+++ b/src/main/kotlin/nexters/admin/exception/CustomExceptions.kt
@@ -33,6 +33,7 @@ class NotFoundException(message: String?) : RuntimeException(message) {
     companion object {
         fun attendanceNotFound() = NotFoundException("존재하지 않는 출석 정보입니다.")
         fun memberNotFound() = NotFoundException("존재하지 않는 회원입니다.")
+        fun generationMemberNotFound() = NotFoundException("존재하지 않는 기수회원입니다.")
         fun sessionNotFound() = NotFoundException("존재하지 않는 세션입니다.")
         fun qrCodeNotFound() = NotFoundException("유효한 QR 코드가 존재하지 않습니다.")
         fun generationNotFound() = NotFoundException("존재하지 않는 기수입니다.")

--- a/src/main/kotlin/nexters/admin/exception/CustomExceptions.kt
+++ b/src/main/kotlin/nexters/admin/exception/CustomExceptions.kt
@@ -31,6 +31,7 @@ class ForbiddenException(message: String?) : RuntimeException(message)
 
 class NotFoundException(message: String?) : RuntimeException(message) {
     companion object {
+        fun attendanceNotFound() = NotFoundException("존재하지 않는 출석 정보입니다.")
         fun memberNotFound() = NotFoundException("존재하지 않는 회원입니다.")
         fun sessionNotFound() = NotFoundException("존재하지 않는 세션입니다.")
         fun qrCodeNotFound() = NotFoundException("유효한 QR 코드가 존재하지 않습니다.")

--- a/src/main/kotlin/nexters/admin/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/nexters/admin/repository/AttendanceRepository.kt
@@ -13,6 +13,7 @@ fun AttendanceRepository.findAllPendingAttendanceOf(sessionId: Long): List<Atten
 }
 
 interface AttendanceRepository : JpaRepository<Attendance, Long> {
+    fun findAllByGenerationMemberId(generationMemberId: Long): List<Attendance>
     fun findAllByGenerationMemberIdAndAttendanceStatusIn(generationMemberId: Long, statuses: List<AttendanceStatus>): List<Attendance>
     fun findByGenerationMemberIdAndSessionId(generationMemberId: Long, sessionId: Long): Attendance?
     fun findAllBySessionIdAndAttendanceStatus(sessionId: Long, statuses: AttendanceStatus): List<Attendance>

--- a/src/main/kotlin/nexters/admin/service/attendance/AttendanceService.kt
+++ b/src/main/kotlin/nexters/admin/service/attendance/AttendanceService.kt
@@ -74,6 +74,11 @@ class AttendanceService(
         attendance.updateStatusByQr(validCode.type)
     }
 
+    fun addExtraAttendanceScoreByAdministrator(attendanceId: Long, extraScoreChange: Int, extraScoreNote: String?) {
+        val attendance = attendanceRepository.findByIdOrNull(attendanceId) ?: throw NotFoundException.attendanceNotFound()
+        attendance.addExtraScore(extraScoreChange, extraScoreNote)
+    }
+
     fun updateAttendanceStatusByAdministrator(attendanceId: Long, attendanceStatus: String, note: String?) {
         val attendance = attendanceRepository.findByIdOrNull(attendanceId) ?: throw NotFoundException.attendanceNotFound()
         attendance.updateStatusByAdmin(AttendanceStatus.from(attendanceStatus), note)

--- a/src/main/kotlin/nexters/admin/service/attendance/AttendanceService.kt
+++ b/src/main/kotlin/nexters/admin/service/attendance/AttendanceService.kt
@@ -14,6 +14,7 @@ import nexters.admin.repository.QrCodeRepository
 import nexters.admin.repository.SessionRepository
 import nexters.admin.repository.findAllPendingAttendanceOf
 import nexters.admin.repository.findGenerationAttendancesIn
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -70,7 +71,12 @@ class AttendanceService(
                 ?: throw BadRequestException.notGenerationMember()
         val attendance = attendanceRepository.findByGenerationMemberIdAndSessionId(generationMember.id, validCode.sessionId)
                 ?: throw NotFoundException.sessionNotFound()
-        attendance.updateStatus(validCode.type)
+        attendance.updateStatusByQr(validCode.type)
+    }
+
+    fun updateAttendanceStatusByAdministrator(attendanceId: Long, attendanceStatus: String, note: String?) {
+        val attendance = attendanceRepository.findByIdOrNull(attendanceId) ?: throw NotFoundException.attendanceNotFound()
+        attendance.updateStatusByAdmin(AttendanceStatus.from(attendanceStatus), note)
     }
 
     fun endAttendance() {
@@ -80,7 +86,7 @@ class AttendanceService(
 
         val pendingAttendances = attendanceRepository.findAllPendingAttendanceOf(activeSessionId)
         pendingAttendances.forEach {
-            it.updateStatus(AttendanceStatus.UNAUTHORIZED_ABSENCE)
+            it.updateStatusByQr(AttendanceStatus.UNAUTHORIZED_ABSENCE)
         }
     }
 

--- a/src/test/kotlin/nexters/admin/acceptance/AttendanceAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/admin/acceptance/AttendanceAcceptanceTest.kt
@@ -105,7 +105,6 @@ class AttendanceAcceptanceTest : AcceptanceTest() {
 
         val attendance1Id = 세션_출석_조회(adminToken, session1Id).data[0].attendanceId
         출석_수정(adminToken, attendance1Id, TARDY.name, "지각 사후 통보")
-
         val attendance = 나의_출석_조회(memberToken).attendanceData
 
         attendance?.score shouldBe 100 - 15 - 5
@@ -125,7 +124,6 @@ class AttendanceAcceptanceTest : AcceptanceTest() {
 
         val attendanceId = 세션_출석_조회(adminToken, sessionId).data[0].attendanceId
         출석_점수_부여(adminToken, attendanceId, 5, "운영 지원")
-
         val attendance = 나의_출석_조회(memberToken).attendanceData
 
         attendance?.score shouldBe 100 + 5

--- a/src/test/kotlin/nexters/admin/acceptance/AttendanceAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/admin/acceptance/AttendanceAcceptanceTest.kt
@@ -3,20 +3,15 @@ package nexters.admin.acceptance
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.restassured.module.kotlin.extensions.Extract
-import io.restassured.module.kotlin.extensions.Given
-import io.restassured.module.kotlin.extensions.Then
-import io.restassured.module.kotlin.extensions.When
-import nexters.admin.domain.attendance.AttendanceStatus
+import nexters.admin.domain.attendance.AttendanceStatus.ATTENDED
+import nexters.admin.domain.attendance.AttendanceStatus.TARDY
+import nexters.admin.domain.attendance.AttendanceStatus.UNAUTHORIZED_ABSENCE
 import nexters.admin.domain.generation.GenerationStatus
 import nexters.admin.domain.user.member.MemberStatus
-import nexters.admin.service.attendance.AttendanceSessionResponses
-import nexters.admin.service.attendance.FindAttendanceProfileResponse
 import nexters.admin.testsupport.AcceptanceTest
 import nexters.admin.testsupport.generateCreateMemberRequest
 import nexters.admin.testsupport.generateCreateSessionRequest
 import org.junit.jupiter.api.Test
-import org.springframework.http.MediaType
 
 class AttendanceAcceptanceTest : AcceptanceTest() {
 
@@ -30,26 +25,16 @@ class AttendanceAcceptanceTest : AcceptanceTest() {
         val session2Id = 세션_생성(adminToken, generateCreateSessionRequest(week = 2)).sessionId
         val session3Id = 세션_생성(adminToken, generateCreateSessionRequest(week = 3)).sessionId
 
-        val qrCode1 = 출석_시작_및_qr_조회(adminToken, session1Id, AttendanceStatus.ATTENDED).qrCode
+        val qrCode1 = 출석_시작_및_qr_조회(adminToken, session1Id, ATTENDED).qrCode
         회원_출석(memberToken, qrCode1)
         출석_종료(adminToken)
-        val qrCode2 = 출석_시작_및_qr_조회(adminToken, session2Id, AttendanceStatus.TARDY).qrCode
+        val qrCode2 = 출석_시작_및_qr_조회(adminToken, session2Id, TARDY).qrCode
         회원_출석(memberToken, qrCode2)
         출석_종료(adminToken)
-        val qrCode3 = 출석_시작_및_qr_조회(adminToken, session3Id, AttendanceStatus.ATTENDED).qrCode
+        val qrCode3 = 출석_시작_및_qr_조회(adminToken, session3Id, ATTENDED).qrCode
         회원_출석(memberToken, qrCode3)
 
-        val findAttendanceProfileResponse = Given {
-            log().all()
-            contentType(MediaType.APPLICATION_JSON_VALUE)
-            auth().oauth2(memberToken)
-        } When {
-            get("/api/attendance/me")
-        } Then {
-            statusCode(200)
-        } Extract {
-            `as`(FindAttendanceProfileResponse::class.java)
-        }
+        val findAttendanceProfileResponse = 나의_출석_조회(memberToken)
 
         findAttendanceProfileResponse.isGenerationMember shouldBe true
         findAttendanceProfileResponse.attendanceData?.attendances?.shouldHaveSize(3)
@@ -67,22 +52,12 @@ class AttendanceAcceptanceTest : AcceptanceTest() {
         val memberToken2 = 회원_생성_토큰_발급(adminToken, generateCreateMemberRequest(name = "정진우", email = "jjw@jjw.com"))
         val sessionId = 세션_생성(adminToken, generateCreateSessionRequest()).sessionId
 
-        val qrCode1 = 출석_시작_및_qr_조회(adminToken, sessionId, AttendanceStatus.ATTENDED).qrCode
+        val qrCode1 = 출석_시작_및_qr_조회(adminToken, sessionId, ATTENDED).qrCode
         회원_출석(memberToken1, qrCode1)
-        val qrCode2 = 출석_시작_및_qr_조회(adminToken, sessionId, AttendanceStatus.TARDY).qrCode
+        val qrCode2 = 출석_시작_및_qr_조회(adminToken, sessionId, TARDY).qrCode
         회원_출석(memberToken2, qrCode2)
 
-        val attendanceSessionResponses = Given {
-            log().all()
-            contentType(MediaType.APPLICATION_JSON_VALUE)
-            auth().oauth2(adminToken)
-        } When {
-            get("/api/attendance/{sessionId}", sessionId)
-        } Then {
-            statusCode(200)
-        } Extract {
-            `as`(AttendanceSessionResponses::class.java)
-        }
+        val attendanceSessionResponses = 세션_출석_조회(adminToken, sessionId)
 
         attendanceSessionResponses.attended shouldBe 1
         attendanceSessionResponses.tardy shouldBe 1
@@ -102,26 +77,58 @@ class AttendanceAcceptanceTest : AcceptanceTest() {
         회원_생성_토큰_발급(adminToken, generateCreateMemberRequest(name = "정진우", email = "jjw@jjw.com"))
         val sessionId = 세션_생성(adminToken, generateCreateSessionRequest()).sessionId
 
-        val qrCode = 출석_시작_및_qr_조회(adminToken, sessionId, AttendanceStatus.ATTENDED).qrCode
+        val qrCode = 출석_시작_및_qr_조회(adminToken, sessionId, ATTENDED).qrCode
         회원_출석(memberToken1, qrCode)
-        출석_시작_및_qr_조회(adminToken, sessionId, AttendanceStatus.TARDY).qrCode
+        출석_시작_및_qr_조회(adminToken, sessionId, TARDY).qrCode
         출석_종료(adminToken)
 
-        val attendanceSessionResponses = Given {
-            log().all()
-            contentType(MediaType.APPLICATION_JSON_VALUE)
-            auth().oauth2(adminToken)
-        } When {
-            get("/api/attendance/{sessionId}", sessionId)
-        } Then {
-            statusCode(200)
-        } Extract {
-            `as`(AttendanceSessionResponses::class.java)
-        }
+        val attendanceSessionResponses = 세션_출석_조회(adminToken, sessionId)
 
         attendanceSessionResponses.attended shouldBe 1
         attendanceSessionResponses.tardy shouldBe 0
         attendanceSessionResponses.absence shouldBe 1
         attendanceSessionResponses.data.map { it.initialGeneration } shouldContainExactly listOf(21, 22)
+    }
+
+    @Test
+    fun `무단결석 처리된 출석을 지각으로 수정`() {
+        val adminToken = 관리자_생성_토큰_발급()
+        기수_생성(adminToken, 22)
+        기수_상태_변경(adminToken, 22, GenerationStatus.DURING_ACTIVITY.value!!)
+        val memberToken = 회원_생성_토큰_발급(adminToken, generateCreateMemberRequest())
+        val session1Id = 세션_생성(adminToken, generateCreateSessionRequest(week = 1)).sessionId
+        val session2Id = 세션_생성(adminToken, generateCreateSessionRequest(week = 2)).sessionId
+        출석_시작_및_qr_조회(adminToken, session1Id, ATTENDED)
+        출석_종료(adminToken)
+        출석_시작_및_qr_조회(adminToken, session2Id, ATTENDED)
+        출석_종료(adminToken)
+
+        val attendance1Id = 세션_출석_조회(adminToken, session1Id).data[0].attendanceId
+        출석_수정(adminToken, attendance1Id, TARDY.name, "지각 사후 통보")
+
+        val attendance = 나의_출석_조회(memberToken).attendanceData
+
+        attendance?.score shouldBe 100 - 15 - 5
+        attendance?.attendances?.get(0)?.attendanceStatus shouldBe UNAUTHORIZED_ABSENCE
+        attendance?.attendances?.get(1)?.attendanceStatus shouldBe TARDY
+    }
+
+    @Test
+    fun `가산점 부여`() {
+        val adminToken = 관리자_생성_토큰_발급()
+        기수_생성(adminToken, 22)
+        기수_상태_변경(adminToken, 22, GenerationStatus.DURING_ACTIVITY.value!!)
+        val memberToken = 회원_생성_토큰_발급(adminToken, generateCreateMemberRequest())
+        val sessionId = 세션_생성(adminToken, generateCreateSessionRequest(week = 1)).sessionId
+        val qrCode = 출석_시작_및_qr_조회(adminToken, sessionId, ATTENDED).qrCode
+        회원_출석(memberToken, qrCode)
+
+        val attendanceId = 세션_출석_조회(adminToken, sessionId).data[0].attendanceId
+        출석_점수_부여(adminToken, attendanceId, 5, "운영 지원")
+
+        val attendance = 나의_출석_조회(memberToken).attendanceData
+
+        attendance?.score shouldBe 100 + 5
+        attendance?.attendances?.get(0)?.attendanceStatus shouldBe ATTENDED
     }
 }

--- a/src/test/kotlin/nexters/admin/domain/attendance/AttendanceTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/attendance/AttendanceTest.kt
@@ -1,14 +1,14 @@
 package nexters.admin.domain.attendance
 
 import io.kotest.matchers.shouldBe
-import nexters.admin.testsupport.createNewAttendance
+import nexters.admin.testsupport.createNewPendingAttendance
 import org.junit.jupiter.api.Test
 
 class AttendanceTest {
 
     @Test
     fun `QR 코드 혹은 관리자에 의한 출석 상태 수정시 기존 출석 상태를 기준으로 점수 변화`() {
-        val attendance = createNewAttendance()
+        val attendance = createNewPendingAttendance()
 
         attendance.updateStatusByAdmin(AttendanceStatus.AUTHORIZED_ABSENCE, "통보 결석")
         attendance.updateStatusByQr(AttendanceStatus.TARDY)
@@ -20,7 +20,7 @@ class AttendanceTest {
 
     @Test
     fun `추가 점수 및 기타 점수 설명 입력시, 해당 점수만큼 점수 변화`() {
-        val attendance = createNewAttendance()
+        val attendance = createNewPendingAttendance()
         val extraScoreChange = 5
 
         attendance.updateStatusByQr(AttendanceStatus.AUTHORIZED_ABSENCE)

--- a/src/test/kotlin/nexters/admin/domain/attendance/AttendanceTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/attendance/AttendanceTest.kt
@@ -1,0 +1,33 @@
+package nexters.admin.domain.attendance
+
+import io.kotest.matchers.shouldBe
+import nexters.admin.testsupport.createNewAttendance
+import org.junit.jupiter.api.Test
+
+class AttendanceTest {
+
+    @Test
+    fun `QR 코드 혹은 관리자에 의한 출석 상태 수정시 기존 출석 상태를 기준으로 점수 변화`() {
+        val attendance = createNewAttendance()
+
+        attendance.updateStatusByAdmin(AttendanceStatus.AUTHORIZED_ABSENCE, "통보 결석")
+        attendance.updateStatusByQr(AttendanceStatus.TARDY)
+        attendance.updateStatusByAdmin(AttendanceStatus.TARDY, "지각 확정")
+
+        attendance.scoreChanged shouldBe AttendanceStatus.TARDY.penaltyScore
+        attendance.note shouldBe "지각 확정"
+    }
+
+    @Test
+    fun `추가 점수 및 기타 점수 설명 입력시, 해당 점수만큼 점수 변화`() {
+        val attendance = createNewAttendance()
+        val extraScoreChange = 5
+
+        attendance.updateStatusByQr(AttendanceStatus.AUTHORIZED_ABSENCE)
+        attendance.addExtraScore(extraScoreChange, "운영 지원")
+        attendance.updateStatusByAdmin(AttendanceStatus.AUTHORIZED_ABSENCE, "변화 없음")
+
+        attendance.scoreChanged shouldBe extraScoreChange + AttendanceStatus.AUTHORIZED_ABSENCE.penaltyScore
+        attendance.extraScoreNote shouldBe "운영 지원"
+    }
+}

--- a/src/test/kotlin/nexters/admin/domain/generation_member/GenerationMemberTest.kt
+++ b/src/test/kotlin/nexters/admin/domain/generation_member/GenerationMemberTest.kt
@@ -17,6 +17,15 @@ class GenerationMemberTest {
     }
 
     @Test
+    fun `점수 변화 내역을 기준으로 현재 출결 점수 다시 계산하여 수정`() {
+        val generationMember = createNewGenerationMember(score = 50)
+
+        generationMember.updateScoreByChanges(listOf(-5, -10, -10, 10))
+
+        generationMember.score shouldBe MAX_SCORE - 15
+    }
+
+    @Test
     fun `운영진 여부 반환`() {
         val generationMember =  createNewGenerationMember(position = Position.MANAGER)
 

--- a/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
@@ -99,14 +99,13 @@ fun createNewAttendance(
         generationMemberId: Long = 0L,
         sessionId: Long = 0L,
         attendanceStatus: AttendanceStatus = AttendanceStatus.ATTENDED,
-        scoreChanged: Int = 0
 ): Attendance {
     return Attendance(
             attendTime = attendTime,
             generationMemberId = generationMemberId,
             sessionId = sessionId,
             attendanceStatus = attendanceStatus,
-            scoreChanged = scoreChanged
+            scoreChanged = attendanceStatus.penaltyScore
     )
 }
 

--- a/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
@@ -99,10 +99,29 @@ fun createNewAttendance(
         attendTime: LocalDateTime = LocalDateTime.of(2023, 1, 7, 14, 3),
         generationMemberId: Long = 0L,
         sessionId: Long = 0L,
-        attendanceStatus: AttendanceStatus = AttendanceStatus.ATTENDED
+        attendanceStatus: AttendanceStatus = AttendanceStatus.ATTENDED,
+        scoreChanged: Int = 0
 ): Attendance {
-    return Attendance(attendTime, generationMemberId, sessionId, attendanceStatus)
+    return Attendance(
+            attendTime = attendTime,
+            generationMemberId = generationMemberId,
+            sessionId = sessionId,
+            attendanceStatus = attendanceStatus,
+            scoreChanged = scoreChanged
+    )
 }
+
+fun createNewPendingAttendance(
+        generationMemberId: Long = 0L,
+        sessionId: Long = 0L,
+): Attendance {
+    return Attendance(
+            generationMemberId = generationMemberId,
+            sessionId = sessionId,
+            attendanceStatus = AttendanceStatus.PENDING,
+    )
+}
+
 
 fun createNewQrCode(
         sessionId: Long = 1L,

--- a/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
@@ -121,7 +121,6 @@ fun createNewPendingAttendance(
     )
 }
 
-
 fun createNewQrCode(
         sessionId: Long = 1L,
         value: String = "ASDFGH",


### PR DESCRIPTION
closes #60

Attendance 도메인 추가된 컬럼들
- 비고(note): 해당 출결 상태에 대한 전반적인 설명
- 기타 점수(extraScoreNote) : "운영지원"과 같은 가산점/감점에 대한 설명
- 점수 변화(scoreChanged) : 지각, 가산점 등을 전부 고려했을 때, 해당 출결로 인한 점수 변화. 해당 점수 변화들을 합산하고 100에서 뺀게 해당 기수 회원의 최종 점수

## 구현한 기능

1. `PUT /api/attendance/{id}/status` API 구현

  - 특정 회원의 회원의 출결 상태와 함께 비고(ex. 지각에 대한 원인 등)를 수정해주는 기능

2. `POST /api/attendance/{id}/additional-score` API 구현

  - 운영지원 등의 이유로 기타 점수를 부여하는 기능

3. **출석 상태 및 출결 점수 수정시, 해당 기수회원의 총 출결 점수도 자동으로 동기화되도록 구현**

- 일반 회원이 QR 코드를 찍어서 출석/지각을 하게 되면 점수 동기화
- 출석 종료에 의해 무단 결석 처리되었을 때에도 점수 동기화
- 관리자가 출석 상태 수정시에도 점수 동기화
- 관리자가 가산점/감점 부여했을 때에도 점수 동기화

## 유의할 점

- 특정 출결에 대한 점수 변화(`scoreChanged`) 컬럼 값은 덮어씌워지지 않고 무조건 **일정 값만큼 더해지거나 감소**함. 
  - 출결 상태를 변경할 경우, 기존 출결 상태의 패널티 점수와 변경하려는 출결 상태의 패널티 점수를 비교한 변화값만큼 값을 더하거나 뺌. (not 덮어씀)
  - 굳이 이렇게 하는 이유는 [운영지원 +5]과 같은 가산점 부여 이후에, 출결 상태를 수정했을 때 가산점이 지워지지 않도록 하기 위함.
  - 헷갈릴 수 있을 것 같은데 일단은 차악인것 같아서 이렇게 구현함

## 공유사항

- 인수테스트 없이 일단 서비스 & 도메인 테스트만 구현 완료