### PR TITLE
feat: 기수 회원 등록시 출석 정보 추가 기능 구현

### DIFF
--- a/src/main/kotlin/nexters/admin/repository/SessionRepository.kt
+++ b/src/main/kotlin/nexters/admin/repository/SessionRepository.kt
@@ -10,6 +10,5 @@ fun SessionRepository.findUpcomingSession(generation: Int, today: LocalDate): Se
 
 interface SessionRepository : JpaRepository<Session, Long> {
     fun findAllByGeneration(generation: Int): List<Session>
-
     fun findTopByGenerationAndSessionTimeGreaterThanEqualOrderBySessionTimeAsc(generation: Int, today: LocalDate): Session?
 }

--- a/src/main/kotlin/nexters/admin/service/user/MemberService.kt
+++ b/src/main/kotlin/nexters/admin/service/user/MemberService.kt
@@ -39,11 +39,6 @@ class MemberService(
         private val attendanceRepository: AttendanceRepository,
 ) {
     fun createMemberByAdministrator(request: CreateMemberRequest): Long {
-        val currentGeneration = generationRepository.findAll()
-                .filter { it.status in listOf(BEFORE_ACTIVITY, DURING_ACTIVITY) }
-                .maxByOrNull { it.generation }
-                ?.generation
-
         val savedMember = memberRepository.save(
                 Member.of(
                         request.name,
@@ -53,6 +48,11 @@ class MemberService(
                         request.status
                 )
         )
+
+        val currentGeneration = generationRepository.findAll()
+                .filter { it.status in listOf(BEFORE_ACTIVITY, DURING_ACTIVITY) }
+                .maxByOrNull { it.generation }
+                ?.generation
 
         currentGeneration?.let {
             if (request.generations.contains(it)) {

--- a/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
@@ -21,6 +21,7 @@ import nexters.admin.repository.MemberRepository
 import nexters.admin.repository.SessionRepository
 import nexters.admin.testsupport.ApplicationTest
 import nexters.admin.testsupport.PHONE_NUMBER
+import nexters.admin.testsupport.createExcelInput
 import nexters.admin.testsupport.createNewAttendance
 import nexters.admin.testsupport.createNewGenerationMember
 import nexters.admin.testsupport.createNewMember
@@ -154,7 +155,7 @@ class MemberServiceTest(
     @Test
     fun `회원 복수 생성시 엑셀 정보를 토대로 회원과 기수 회원 모두 생성`() {
         val generation = 22
-        val excelInput = getExcelInput()
+        val excelInput = createExcelInput()
 
         memberService.createGenerationMembers(generation, excelInput)
         memberRepository.flush()
@@ -169,7 +170,7 @@ class MemberServiceTest(
     @Test
     fun `회원 복수 생성시 이메일을 기준으로 이미 생성된 회원 정보는 이메일을 그대로 덮어씌어짐`() {
         val generation = 22
-        val excelInput = getExcelInput()
+        val excelInput = createExcelInput()
         val existingMember = memberRepository.save(createNewMember(email = "jinwoo@gmail.com", name = "기존이름"))
         memberRepository.save(createNewMember(email = "not@matching.email"))
         memberService.createGenerationMembers(generation, excelInput)
@@ -184,7 +185,7 @@ class MemberServiceTest(
     @Test
     fun `회원 복수 생성시 이메일과 기수 정보를 기준으로 이미 생성된 기수회원의 직군 정보만 그대로 덮어씌어짐`() {
         val generation = 22
-        val excelInput = getExcelInput()
+        val excelInput = createExcelInput()
         val existingMember = memberRepository.save(createNewMember(email = "jinwoo@gmail.com"))
         val existingMatchingGenerationMember = generationMemberRepository.save(
                 createNewGenerationMember(memberId = existingMember.id, generation = generation, position = Position.NULL)
@@ -202,7 +203,7 @@ class MemberServiceTest(
     @Test
     fun `회원 복수 생성시 이미 세션이 존재하면 출석 정보 추가`() {
         initGenerationsAndSessions()
-        val excelInput = getExcelInput()
+        val excelInput = createExcelInput()
         memberService.createGenerationMembers(generation = 22, excelInput)
 
         val attendances = attendanceRepository.findAll()
@@ -217,7 +218,7 @@ class MemberServiceTest(
     fun `회원 복수 생성시 이미 생성된 기수회원이면 존재하는 세션에 대한 출석 정보가 새롭게 추가되지 않는다`() {
         val generation = 22
         initGenerationsAndSessions()
-        val excelInput = getExcelInput()
+        val excelInput = createExcelInput()
         val existingMember = memberRepository.save(createNewMember(email = "jinwoo@gmail.com"))
         val generationMember = generationMemberRepository.save(createNewGenerationMember(memberId = existingMember.id, generation = 22))
         sessionRepository.findAll().forEach {
@@ -233,16 +234,6 @@ class MemberServiceTest(
             it.attendanceStatus shouldBe ATTENDED
         }
     }
-
-    private fun getExcelInput() = mutableMapOf(
-            "name" to mutableListOf("정진우", "김민수", "최다예"),
-            "gender" to mutableListOf("남자", "남자", "여자"),
-            "email" to mutableListOf("jinwoo@gmail.com", "ming@gmail.com", "dayeah@gmail.com"),
-            "phone_number" to mutableListOf("01012345678", "01012345679", "01012345670"),
-            "position" to mutableListOf("개발자", "운영진", "디자이너"),
-            "sub_position" to mutableListOf("프론트엔드", "CTO", ""),
-            "status" to mutableListOf("미이수", "수료", "제명")
-    )
 
     private fun initGenerationsAndSessions() {
         generationRepository.save(Generation(21))

--- a/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import nexters.admin.controller.user.CreateMemberRequest
+import nexters.admin.domain.generation.Generation
 import nexters.admin.domain.generation_member.GenerationMember
 import nexters.admin.domain.generation_member.Position
 import nexters.admin.domain.generation_member.SubPosition
@@ -53,6 +54,7 @@ class MemberServiceTest(
 
     @Test
     fun `회원 저장 시 최신 기수회원 정보 저장`() {
+        generationRepository.save(Generation(22))
         val memberId = memberService.createMemberByAdministrator(
                 CreateMemberRequest(
                         "김태현",

--- a/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
@@ -204,8 +204,6 @@ class MemberServiceTest(
         initGenerationsAndSessions()
         val excelInput = getExcelInput()
         memberService.createGenerationMembers(generation = 22, excelInput)
-        memberRepository.flush()
-        generationMemberRepository.flush()
 
         val attendances = attendanceRepository.findAll()
 
@@ -228,8 +226,6 @@ class MemberServiceTest(
             }
         }
         memberService.createGenerationMembers(generation, excelInput)
-        memberRepository.flush()
-        generationMemberRepository.flush()
 
         val attendances = attendanceRepository.findAll().filter { it.generationMemberId == generationMember.id }
         attendances.size shouldBe 8

--- a/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
+++ b/src/test/kotlin/nexters/admin/service/user/MemberServiceTest.kt
@@ -4,6 +4,8 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import nexters.admin.controller.user.CreateMemberRequest
+import nexters.admin.domain.attendance.AttendanceStatus.ATTENDED
+import nexters.admin.domain.attendance.AttendanceStatus.PENDING
 import nexters.admin.domain.generation.Generation
 import nexters.admin.domain.generation_member.GenerationMember
 import nexters.admin.domain.generation_member.Position
@@ -12,13 +14,17 @@ import nexters.admin.domain.user.Password
 import nexters.admin.domain.user.member.Member
 import nexters.admin.domain.user.member.MemberStatus
 import nexters.admin.exception.NotFoundException
+import nexters.admin.repository.AttendanceRepository
 import nexters.admin.repository.GenerationMemberRepository
 import nexters.admin.repository.GenerationRepository
 import nexters.admin.repository.MemberRepository
+import nexters.admin.repository.SessionRepository
 import nexters.admin.testsupport.ApplicationTest
 import nexters.admin.testsupport.PHONE_NUMBER
+import nexters.admin.testsupport.createNewAttendance
 import nexters.admin.testsupport.createNewGenerationMember
 import nexters.admin.testsupport.createNewMember
+import nexters.admin.testsupport.createNewSession
 import nexters.admin.testsupport.createUpdateMemberRequest
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -30,6 +36,8 @@ class MemberServiceTest(
         @Autowired private val memberRepository: MemberRepository,
         @Autowired private val generationMemberRepository: GenerationMemberRepository,
         @Autowired private val generationRepository: GenerationRepository,
+        @Autowired private val sessionRepository: SessionRepository,
+        @Autowired private val attendanceRepository: AttendanceRepository,
 ) {
     @Test
     fun `회원 저장`() {
@@ -54,6 +62,7 @@ class MemberServiceTest(
 
     @Test
     fun `회원 저장 시 최신 기수회원 정보 저장`() {
+        generationRepository.save(Generation(21))
         generationRepository.save(Generation(22))
         val memberId = memberService.createMemberByAdministrator(
                 CreateMemberRequest(
@@ -120,17 +129,32 @@ class MemberServiceTest(
     }
 
     @Test
+    fun `회원 단건 생성시 세션이 존재하면 출석 정보 추가`() {
+        initGenerationsAndSessions()
+        val memberId = memberService.createMemberByAdministrator(
+                CreateMemberRequest(
+                        "김태현",
+                        "남자",
+                        "kth990303@naver.com",
+                        PHONE_NUMBER,
+                        mutableListOf(14, 19, 22),
+                        "개발자",
+                        "백엔드",
+                        "미이수",
+                )
+        )
+        val generationMember = generationMemberRepository.findByGenerationAndMemberId(22, memberId)
+        val attendances = attendanceRepository.findAll().filter { it.generationMemberId == generationMember!!.id }
+        attendances.size shouldBe 8
+        attendances.forEach {
+            it.attendanceStatus shouldBe PENDING
+        }
+    }
+
+    @Test
     fun `회원 복수 생성시 엑셀 정보를 토대로 회원과 기수 회원 모두 생성`() {
         val generation = 22
-        val excelInput = mutableMapOf(
-                "name" to mutableListOf("정진우", "김민수", "최다예"),
-                "gender" to mutableListOf("남자", "남자", "여자"),
-                "email" to mutableListOf("jinwoo@gmail.com", "ming@gmail.com", "dayeah@gmail.com"),
-                "phone_number" to mutableListOf("01012345678", "01012345679", "01012345670"),
-                "position" to mutableListOf("개발자", "운영진", "디자이너"),
-                "sub_position" to mutableListOf("프론트엔드", "CTO", ""),
-                "status" to mutableListOf("미이수", "수료", "제명")
-        )
+        val excelInput = getExcelInput()
 
         memberService.createGenerationMembers(generation, excelInput)
         memberRepository.flush()
@@ -145,15 +169,7 @@ class MemberServiceTest(
     @Test
     fun `회원 복수 생성시 이메일을 기준으로 이미 생성된 회원 정보는 이메일을 그대로 덮어씌어짐`() {
         val generation = 22
-        val excelInput = mutableMapOf(
-                "name" to mutableListOf("정진우", "김민수", "최다예"),
-                "gender" to mutableListOf("남자", "남자", "여자"),
-                "email" to mutableListOf("jinwoo@gmail.com", "ming@gmail.com", "dayeah@gmail.com"),
-                "phone_number" to mutableListOf("01012345678", "01012345679", "01012345670"),
-                "position" to mutableListOf("개발자", "운영진", "디자이너"),
-                "sub_position" to mutableListOf("프론트엔드", "CTO", ""),
-                "status" to mutableListOf("미이수", "수료", "제명")
-        )
+        val excelInput = getExcelInput()
         val existingMember = memberRepository.save(createNewMember(email = "jinwoo@gmail.com", name = "기존이름"))
         memberRepository.save(createNewMember(email = "not@matching.email"))
         memberService.createGenerationMembers(generation, excelInput)
@@ -168,15 +184,7 @@ class MemberServiceTest(
     @Test
     fun `회원 복수 생성시 이메일과 기수 정보를 기준으로 이미 생성된 기수회원의 직군 정보만 그대로 덮어씌어짐`() {
         val generation = 22
-        val excelInput = mutableMapOf(
-                "name" to mutableListOf("정진우", "김민수", "최다예"),
-                "gender" to mutableListOf("남자", "남자", "여자"),
-                "email" to mutableListOf("jinwoo@gmail.com", "ming@gmail.com", "dayeah@gmail.com"),
-                "phone_number" to mutableListOf("01012345678", "01012345679", "01012345670"),
-                "position" to mutableListOf("개발자", "운영진", "디자이너"),
-                "sub_position" to mutableListOf("프론트엔드", "CTO", ""),
-                "status" to mutableListOf("미이수", "수료", "제명")
-        )
+        val excelInput = getExcelInput()
         val existingMember = memberRepository.save(createNewMember(email = "jinwoo@gmail.com"))
         val existingMatchingGenerationMember = generationMemberRepository.save(
                 createNewGenerationMember(memberId = existingMember.id, generation = generation, position = Position.NULL)
@@ -189,6 +197,64 @@ class MemberServiceTest(
         generationMemberRepository.findByIdOrNull(existingMatchingGenerationMember.id)?.position shouldBe Position.DEVELOPER
         memberRepository.findAll() shouldHaveSize 3
         generationMemberRepository.findAll() shouldHaveSize 4
+    }
+
+    @Test
+    fun `회원 복수 생성시 이미 세션이 존재하면 출석 정보 추가`() {
+        initGenerationsAndSessions()
+        val excelInput = getExcelInput()
+        memberService.createGenerationMembers(generation = 22, excelInput)
+        memberRepository.flush()
+        generationMemberRepository.flush()
+
+        val attendances = attendanceRepository.findAll()
+
+        attendances.size shouldBe 8 * 3
+        attendances.forEach {
+            it.attendanceStatus shouldBe PENDING
+        }
+    }
+
+    @Test
+    fun `회원 복수 생성시 이미 생성된 기수회원이면 존재하는 세션에 대한 출석 정보가 새롭게 추가되지 않는다`() {
+        val generation = 22
+        initGenerationsAndSessions()
+        val excelInput = getExcelInput()
+        val existingMember = memberRepository.save(createNewMember(email = "jinwoo@gmail.com"))
+        val generationMember = generationMemberRepository.save(createNewGenerationMember(memberId = existingMember.id, generation = 22))
+        sessionRepository.findAll().forEach {
+            if (it.generation == generation) {
+                attendanceRepository.save(createNewAttendance(sessionId = it.id, generationMemberId = generationMember.id, attendanceStatus = ATTENDED))
+            }
+        }
+        memberService.createGenerationMembers(generation, excelInput)
+        memberRepository.flush()
+        generationMemberRepository.flush()
+
+        val attendances = attendanceRepository.findAll().filter { it.generationMemberId == generationMember.id }
+        attendances.size shouldBe 8
+        attendances.forEach {
+            it.attendanceStatus shouldBe ATTENDED
+        }
+    }
+
+    private fun getExcelInput() = mutableMapOf(
+            "name" to mutableListOf("정진우", "김민수", "최다예"),
+            "gender" to mutableListOf("남자", "남자", "여자"),
+            "email" to mutableListOf("jinwoo@gmail.com", "ming@gmail.com", "dayeah@gmail.com"),
+            "phone_number" to mutableListOf("01012345678", "01012345679", "01012345670"),
+            "position" to mutableListOf("개발자", "운영진", "디자이너"),
+            "sub_position" to mutableListOf("프론트엔드", "CTO", ""),
+            "status" to mutableListOf("미이수", "수료", "제명")
+    )
+
+    private fun initGenerationsAndSessions() {
+        generationRepository.save(Generation(21))
+        generationRepository.save(Generation(22))
+        for (i in 1..8) {
+            sessionRepository.save(createNewSession(generation = 21, week = i))
+            sessionRepository.save(createNewSession(generation = 22, week = i))
+        }
     }
 
     @Test

--- a/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
@@ -119,7 +119,6 @@ fun createNewGeneration(
     return Generation(generation, GenerationStatus.from(status))
 }
 
-
 fun createExcelInput() = mutableMapOf(
         "name" to mutableListOf("정진우", "김민수", "최다예"),
         "gender" to mutableListOf("남자", "남자", "여자"),

--- a/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
+++ b/src/test/kotlin/nexters/admin/testsupport/Fixtures.kt
@@ -118,3 +118,14 @@ fun createNewGeneration(
 ): Generation {
     return Generation(generation, GenerationStatus.from(status))
 }
+
+
+fun createExcelInput() = mutableMapOf(
+        "name" to mutableListOf("정진우", "김민수", "최다예"),
+        "gender" to mutableListOf("남자", "남자", "여자"),
+        "email" to mutableListOf("jinwoo@gmail.com", "ming@gmail.com", "dayeah@gmail.com"),
+        "phone_number" to mutableListOf("01012345678", "01012345679", "01012345670"),
+        "position" to mutableListOf("개발자", "운영진", "디자이너"),
+        "sub_position" to mutableListOf("프론트엔드", "CTO", ""),
+        "status" to mutableListOf("미이수", "수료", "제명")
+)


### PR DESCRIPTION
close #62 

- 기수 회원 등록시 해당 기수의 세션이 이미 존재하면, 새롭게 등록된 기수 회원들의 출석 정보를 생성합니다. (상태: PENDING)
- 기수 회원 일괄 등록시, 이미 존재하는 기수 회원의 경우, 출석 정보를 업데이트 하지 않습니다.